### PR TITLE
OAI-42: Change function for fetching data from json_ext 

### DIFF
--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -207,7 +207,7 @@ class ClaimSearcher extends Component {
         }
         if (!!this.extFields && !!this.extFields.length) {
             this.extFields.forEach(f => {
-                result.push(c => !!c.jsonExt ? JSON.parse(c.jsonExt)[f] : "")
+                result.push(c => !!c.jsonExt ? String(_.get(JSON.parse(c.jsonExt), f, "-")) : "")
             })
         }
         result.push(c => (


### PR DESCRIPTION
Required for [OAI-42](https://openimis.atlassian.net/browse/OAI-42). Field "was_categorized" is nested and previous solution didn't allow displaying the value. Currently the configuration can include all fields present in json_ext, also nested and present in the list of values.