### PR TITLE
fix: Remove pre-headers row when not needed

### DIFF
--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -95,8 +95,10 @@ class ClaimSearcher extends Component {
             formatMessage(this.props.intl, "claim", `reviewStatus.${c.reviewStatus}`)
 
     preHeaders = (selection) => {
-        var result = selection.length ?
-            [
+        if (!selection.length) {
+            return []
+        }
+        var result = [
                 '', '', '', '', '', '',
                 <Typography noWrap={true}>
                     <FormattedMessage
@@ -118,7 +120,6 @@ class ClaimSearcher extends Component {
                 </Typography>,
                 '', ''
             ]
-            : ['\u200b', '', '', '', '', '', '', '', '', ''] //fixing pre headers row height!
         if (this.claimAttachments) {
             result.push('')
         }


### PR DESCRIPTION
I've removed the blank line when there are no items selected.