### PR TITLE
OP-1041: extended claim admin query with user's related HF

### DIFF
--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -216,6 +216,7 @@ class Head extends Component {
                 value={this._filterValue("admin")}
                 withNull={true}
                 hfFilter={this._filterValue("healthFacility")}
+                userHealthFacilityId={userHealthFacilityId}
                 reset={this.state.reset}
                 onChange={this._onChangeClaimAdmin}
               />

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -17,6 +17,7 @@ const ClaimAdminPicker = (props) => {
     multiple,
     extraFragment,
     hfFilter,
+    userHealthFacilityId,
   } = props;
 
   const modulesManager = useModulesManager();
@@ -24,8 +25,8 @@ const ClaimAdminPicker = (props) => {
   const [searchString, setSearchString] = useState("");
   const { isLoading, data, error } = useGraphqlQuery(
     `
-      query ClaimAdminPicker ($search: String, $hf: String) {
-          claimAdmins(search: $search, first: 20, healthFacility_Uuid: $hf) {
+      query ClaimAdminPicker ($search: String, $hf: String, $user_health_facility: String) {
+          claimAdmins(search: $search, first: 20, healthFacility_Uuid: $hf, userHealthFacility: $user_health_facility) {
               edges {
                   node {
                       id
@@ -52,7 +53,7 @@ const ClaimAdminPicker = (props) => {
             }
         }
         `,
-    { hf: hfFilter?.uuid, search: searchString },
+    { hf: hfFilter?.uuid, search: searchString, user_health_facility: userHealthFacilityId },
     { skip: true },
   );
 


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OP-1041

Changes:
- extended ClaimAdminPicker and ClaimFilter to pass user's related HF that is required on the backend filtering

Related PR:
https://github.com/openimis/openimis-be-claim_py/pull/65