### PR TITLE
Feature/op 1086: filter for claim admins 

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -324,7 +324,6 @@ export function fetchaAvailableHealthFacilities(mm, variables){
     `,
     variables,
     "CLAIM_HEALTH_FACILITIES",
-    { skip: true },
   )
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -308,7 +308,6 @@ export function fetchClaimOfficers(mm, extraFragment, variables) {
 }
 
 export function fetchaAvailableHealthFacilities(mm, variables){
-  console.log(variables);
   return graphqlWithVariables(
     `
     query HealthFacilityPicker ($str: String, $region: String, $district: [String], $level: String) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -307,6 +307,27 @@ export function fetchClaimOfficers(mm, extraFragment, variables) {
   )
 }
 
+export function fetchaAvailableHealthFacilities(mm, variables){
+  return graphqlWithVariables(
+    `
+    query HealthFacilityPicker ($str: String, $region: String, $district: [String], $level: String) {
+      healthFacilities: healthFacilitiesStr(first: 20, str: $str, regionUuid: $region, districtsUuids: $district, level: $level) {
+        edges {
+          node {
+            uuid
+            code
+            location {uuid, parent { uuid }}
+          }
+        }
+      }
+    }
+    `,
+    variables,
+    "CLAIM_HEALTH_FACILITIES",
+    { skip: true },
+  )
+}
+
 export function submit(claims, clientMutationLabel, clientMutationDetails = null) {
   let claimUuids = `uuids: ["${claims.map((c) => c.uuid).join('","')}"]`;
   let mutation = formatMutation("submitClaims", claimUuids, clientMutationLabel, clientMutationDetails);

--- a/src/actions.js
+++ b/src/actions.js
@@ -308,6 +308,7 @@ export function fetchClaimOfficers(mm, extraFragment, variables) {
 }
 
 export function fetchaAvailableHealthFacilities(mm, variables){
+  console.log(variables);
   return graphqlWithVariables(
     `
     query HealthFacilityPicker ($str: String, $region: String, $district: [String], $level: String) {

--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -216,7 +216,7 @@ class Head extends Component {
                 value={this._filterValue("admin")}
                 withNull={true}
                 hfFilter={this._filterValue("healthFacility")}
-                userHealthFacilityId={userHealthFacilityId || this._filterValue("healthFacility")?.uuid}
+                userHealthFacilityId={userHealthFacilityId}
                 reset={this.state.reset}
                 onChange={this._onChangeClaimAdmin}
                 region={this._filterValue("region")}

--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -219,6 +219,8 @@ class Head extends Component {
                 userHealthFacilityId={userHealthFacilityId || this._filterValue("healthFacility")?.uuid}
                 reset={this.state.reset}
                 onChange={this._onChangeClaimAdmin}
+                region={this._filterValue("region")}
+                district={this._filterValue("district")}
               />
             </Grid>
           }

--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -216,7 +216,7 @@ class Head extends Component {
                 value={this._filterValue("admin")}
                 withNull={true}
                 hfFilter={this._filterValue("healthFacility")}
-                userHealthFacilityId={userHealthFacilityId}
+                userHealthFacilityId={userHealthFacilityId || this._filterValue("healthFacility")?.uuid}
                 reset={this.state.reset}
                 onChange={this._onChangeClaimAdmin}
               />

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -60,36 +60,51 @@ const ClaimAdminPicker = (props) => {
     { skip: true },
   );
 
+  // 1# start location
+  // const userHealthFacility = useSelector((state) => state.loc.userHealthFacilityFullPath);
+  // let pickedDistrictsUuids = [];
+  // Array.isArray(district) ? pickedDistrictsUuids = district?.map((district) => district?.uuid) : pickedDistrictsUuids.push(district?.uuid);
+  // console.log("pickedDistrictsUuids: ", pickedDistrictsUuids);
+  // 1# end
+
   const dispatch = useDispatch();
   const [variables, setVariables] = useState({});
-  const options = useSelector((state) => state.claim.availableHealthFacilities? state.claim.availableHealthFacilities: []);
-//   useEffect(async () => {
-//     await dispatch(
-//       fetchaAvailableHealthFacilities(modulesManager, variables),
-//    );
-//  }, []);
- dispatch(fetchaAvailableHealthFacilities(modulesManager, variables));
+  const options = useSelector((state) => state.claim?.availablehealthFacilities);
+  const region = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.region?.value?.uuid);
+  const district = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.district?.value?.uuid);
+  console.log("region", region); // it does show uuid
+  console.log("district", district); // it does show uuid
+  // setVariables({ region, district }); // here it goes into inf loop and crashes
+  useEffect(async () => {
+    setVariables({ region, district });
+    await dispatch(
+    fetchaAvailableHealthFacilities(modulesManager, variables),
+    );
+}, []);
+//  dispatch(fetchaAvailableHealthFacilities(modulesManager, variables));
+  console.log( variables ); // is shows: {region: undefined, district: undefined }
 
-  return (
-    <Autocomplete
-      multiple={multiple}
-      required={required}
-      placeholder={placeholder ?? formatMessage("ClaimAdminPicker.placeholder")}
-      label={label ?? formatMessage("ClaimAdminPicker.label")}
-      error={error}
-      withLabel={withLabel}
-      withPlaceholder={withPlaceholder}
-      readOnly={readOnly}
-      options={data?.claimAdmins?.edges.map((edge) => edge.node) ?? []}
-      isLoading={isLoading}
-      value={value}
-      getOptionLabel={(option) => `${option.code} ${option.lastName} ${option.otherNames}`}
-      onChange={(option) => onChange(option, option ? `${option.code} ${option.lastName} ${option.otherNames}` : null)}
-      filterOptions={filterOptions}
-      filterSelectedOptions={filterSelectedOptions}
-      onInputChange={setSearchString}
-    />
-  );
+
+return (
+  <Autocomplete
+    multiple={multiple}
+    required={required}
+    placeholder={placeholder ?? formatMessage("ClaimAdminPicker.placeholder")}
+    label={label ?? formatMessage("ClaimAdminPicker.label")}
+    error={error}
+    withLabel={withLabel}
+    withPlaceholder={withPlaceholder}
+    readOnly={readOnly}
+    options={data?.claimAdmins?.edges.map((edge) => edge.node) ?? []}
+    isLoading={isLoading}
+    value={value}
+    getOptionLabel={(option) => `${option.code} ${option.lastName} ${option.otherNames}`}
+    onChange={(option) => onChange(option, option ? `${option.code} ${option.lastName} ${option.otherNames}` : null)}
+    filterOptions={filterOptions}
+    filterSelectedOptions={filterSelectedOptions}
+    onInputChange={setSearchString}
+  />
+);
 };
 
 export default ClaimAdminPicker;

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -26,6 +26,34 @@ const ClaimAdminPicker = (props) => {
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("claim", modulesManager);
   const [searchString, setSearchString] = useState("");
+
+  // 1# start location
+  // const userHealthFacility = useSelector((state) => state.loc.userHealthFacilityFullPath);
+  // let pickedDistrictsUuids = [];
+  // Array.isArray(district) ? pickedDistrictsUuids = district?.map((district) => district?.uuid) : pickedDistrictsUuids.push(district?.uuid);
+  // console.log("pickedDistrictsUuids: ", pickedDistrictsUuids);
+  // 1# end
+
+  const dispatch = useDispatch();
+  const [variables, setVariables] = useState({});
+  const options = useSelector((state) => state.claim?.availablehealthFacilities);
+  const region = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.region?.value?.uuid);
+  const district = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.district?.value?.uuid);
+  // to add flag from location and district
+  // const claim = useSelector((state) => state.claim?.isFetched);
+
+  useEffect(() => {
+    setVariables({ region: props?.region?.uuid, district: [props?.district?.uuid] });
+  }, [region, district]);
+
+  useEffect(() => {
+    dispatch(fetchaAvailableHealthFacilities(modulesManager, variables));
+  }, [variables]);
+
+  let result = options?.map(a => a.uuid);
+  console.log(result);
+  // console.log("varaibles", variables);
+
   const { isLoading, data, error } = useGraphqlQuery(
     `
       query ClaimAdminPicker ($search: String, $hf: String, $user_health_facility: String) {
@@ -60,51 +88,29 @@ const ClaimAdminPicker = (props) => {
     { skip: true },
   );
 
-  // 1# start location
-  // const userHealthFacility = useSelector((state) => state.loc.userHealthFacilityFullPath);
-  // let pickedDistrictsUuids = [];
-  // Array.isArray(district) ? pickedDistrictsUuids = district?.map((district) => district?.uuid) : pickedDistrictsUuids.push(district?.uuid);
-  // console.log("pickedDistrictsUuids: ", pickedDistrictsUuids);
-  // 1# end
-
-  const dispatch = useDispatch();
-  const [variables, setVariables] = useState({});
-  const options = useSelector((state) => state.claim?.availablehealthFacilities);
-  const region = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.region?.value?.uuid);
-  const district = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.district?.value?.uuid);
-  console.log("region", region); // it does show uuid
-  console.log("district", district); // it does show uuid
-  // setVariables({ region, district }); // here it goes into inf loop and crashes
-  useEffect(async () => {
-    setVariables({ region, district });
-    await dispatch(
-    fetchaAvailableHealthFacilities(modulesManager, variables),
-    );
-}, []);
-//  dispatch(fetchaAvailableHealthFacilities(modulesManager, variables));
-  console.log( variables ); // is shows: {region: undefined, district: undefined }
 
 
-return (
-  <Autocomplete
-    multiple={multiple}
-    required={required}
-    placeholder={placeholder ?? formatMessage("ClaimAdminPicker.placeholder")}
-    label={label ?? formatMessage("ClaimAdminPicker.label")}
-    error={error}
-    withLabel={withLabel}
-    withPlaceholder={withPlaceholder}
-    readOnly={readOnly}
-    options={data?.claimAdmins?.edges.map((edge) => edge.node) ?? []}
-    isLoading={isLoading}
-    value={value}
-    getOptionLabel={(option) => `${option.code} ${option.lastName} ${option.otherNames}`}
-    onChange={(option) => onChange(option, option ? `${option.code} ${option.lastName} ${option.otherNames}` : null)}
-    filterOptions={filterOptions}
-    filterSelectedOptions={filterSelectedOptions}
-    onInputChange={setSearchString}
-  />
-);
+
+  return (
+    <Autocomplete
+      multiple={multiple}
+      required={required}
+      placeholder={placeholder ?? formatMessage("ClaimAdminPicker.placeholder")}
+      label={label ?? formatMessage("ClaimAdminPicker.label")}
+      error={error}
+      withLabel={withLabel}
+      withPlaceholder={withPlaceholder}
+      readOnly={readOnly}
+      options={data?.claimAdmins?.edges.map((edge) => edge.node) ?? []}
+      isLoading={isLoading}
+      value={value}
+      getOptionLabel={(option) => `${option.code} ${option.lastName} ${option.otherNames}`}
+      onChange={(option) => onChange(option, option ? `${option.code} ${option.lastName} ${option.otherNames}` : null)}
+      filterOptions={filterOptions}
+      filterSelectedOptions={filterSelectedOptions}
+      onInputChange={setSearchString}
+    />
+  );
 };
 
 export default ClaimAdminPicker;

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -26,10 +26,9 @@ const ClaimAdminPicker = (props) => {
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("claim", modulesManager);
   const [searchString, setSearchString] = useState("");
-
   const dispatch = useDispatch();
   const [variables, setVariables] = useState({});
-  const options = useSelector((state) => state.claim?.availablehealthFacilities);
+  const options = useSelector((state) => state.claim?.healthFacilities.availableHealthFacilities);
   const region = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.region?.value?.uuid);
   const district = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.district?.value?.uuid);
 
@@ -41,9 +40,7 @@ const ClaimAdminPicker = (props) => {
     dispatch(fetchaAvailableHealthFacilities(modulesManager, variables));
   }, [variables]);
 
-  let result = options?.map(a => a.uuid);
-  console.log(result);
-  // console.log("varaibles", variables);
+  let availablehealthFacilities = options?.map(healthfacility => healthfacility.uuid);
 
   const { isLoading, data, error } = useGraphqlQuery(
     `
@@ -75,12 +72,9 @@ const ClaimAdminPicker = (props) => {
             }
         }
         `,
-    { hf: hfFilter?.uuid, search: searchString, user_health_facility: result },
+    { hf: hfFilter?.uuid, search: searchString, user_health_facility: userHealthFacilityId || availablehealthFacilities },
     { skip: true },
   );
-
-
-
 
   return (
     <Autocomplete

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -1,6 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useModulesManager, useTranslations, Autocomplete, useGraphqlQuery } from "@openimis/fe-core";
 import _debounce from "lodash/debounce";
+import { fetchaAvailableHealthFacilities } from "../actions";
+
 
 const ClaimAdminPicker = (props) => {
   const {
@@ -56,6 +59,16 @@ const ClaimAdminPicker = (props) => {
     { hf: hfFilter?.uuid, search: searchString, user_health_facility: userHealthFacilityId },
     { skip: true },
   );
+
+  const dispatch = useDispatch();
+  const [variables, setVariables] = useState({});
+  const options = useSelector((state) => state.claim.availableHealthFacilities? state.claim.availableHealthFacilities: []);
+//   useEffect(async () => {
+//     await dispatch(
+//       fetchaAvailableHealthFacilities(modulesManager, variables),
+//    );
+//  }, []);
+ dispatch(fetchaAvailableHealthFacilities(modulesManager, variables));
 
   return (
     <Autocomplete

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -27,20 +27,11 @@ const ClaimAdminPicker = (props) => {
   const { formatMessage } = useTranslations("claim", modulesManager);
   const [searchString, setSearchString] = useState("");
 
-  // 1# start location
-  // const userHealthFacility = useSelector((state) => state.loc.userHealthFacilityFullPath);
-  // let pickedDistrictsUuids = [];
-  // Array.isArray(district) ? pickedDistrictsUuids = district?.map((district) => district?.uuid) : pickedDistrictsUuids.push(district?.uuid);
-  // console.log("pickedDistrictsUuids: ", pickedDistrictsUuids);
-  // 1# end
-
   const dispatch = useDispatch();
   const [variables, setVariables] = useState({});
   const options = useSelector((state) => state.claim?.availablehealthFacilities);
   const region = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.region?.value?.uuid);
   const district = useSelector((state) => state.core.filtersCache.claimHealthFacilitiesPageFiltersCache?.district?.value?.uuid);
-  // to add flag from location and district
-  // const claim = useSelector((state) => state.claim?.isFetched);
 
   useEffect(() => {
     setVariables({ region: props?.region?.uuid, district: [props?.district?.uuid] });
@@ -84,7 +75,7 @@ const ClaimAdminPicker = (props) => {
             }
         }
         `,
-    { hf: hfFilter?.uuid, search: searchString, user_health_facility: userHealthFacilityId },
+    { hf: hfFilter?.uuid, search: searchString, user_health_facility: result },
     { skip: true },
   );
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -226,10 +226,27 @@ function reducer(
           error: formatGraphQLError(action.payload),
         },
       };
-    case "CLAIM_HEALTH_FACILITIES":
+    case "CLAIM_HEALTH_FACILITIES_REQ":
       return {
         ...state,
-        availablehealthFacilities: parseData(action.payload.data.healthFacilities)
+        isFetching: true,
+        isFetched: false,
+        availablehealthFacilities: null,
+        error: null,
+      };
+    case "CLAIM_HEALTH_FACILITIES_RESP":
+      return {
+        ...state,
+        isFetching: false,
+        isFetched: true,
+        availablehealthFacilities: parseData(action.payload.data.healthFacilities),
+        error: formatGraphQLError(action.payload),
+      };
+    case "CLAIM_HEALTH_FACILITIES_ERR":
+      return {
+        ...state,
+        isFetching: false,
+        error: formatServerError(action.payload),
       };
     case "CLAIM_MUTATION_REQ":
       return dispatchMutationReq(state, action);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -33,6 +33,7 @@ function reducer(
     fetchedClaimCodeCount: false,
     claimCodeCount: null,
     errorClaimCodeCount: null,
+    availablehealthFacilities: [],
     claimOfficers: {
       items: [],
       isFetching: false,
@@ -224,6 +225,11 @@ function reducer(
           isFetched: false,
           error: formatGraphQLError(action.payload),
         },
+      };
+    case "CLAIM_HEALTH_FACILITIES":
+      return {
+        ...state,
+        availablehealthFacilities: parseData(action.payload.data.healthFacilities)
       };
     case "CLAIM_MUTATION_REQ":
       return dispatchMutationReq(state, action);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -34,6 +34,12 @@ function reducer(
     claimCodeCount: null,
     errorClaimCodeCount: null,
     availablehealthFacilities: [],
+    healthFacilities: {
+      availableHealthFacilities: [],
+      isFetching: false,
+      isFetched: false,
+      error: null,
+    },
     claimOfficers: {
       items: [],
       isFetching: false,
@@ -229,25 +235,31 @@ function reducer(
     case "CLAIM_HEALTH_FACILITIES_REQ":
       return {
         ...state,
-        isFetching: true,
-        isFetched: false,
-        availablehealthFacilities: null,
-        error: null,
+        healthFacilities: {
+          availableHealthFacilities: null,
+          isFetching: true,
+          isFetched: false,
+          error: null,
+        },
       };
     case "CLAIM_HEALTH_FACILITIES_RESP":
       return {
         ...state,
-        isFetching: false,
-        isFetched: true,
-        availablehealthFacilities: parseData(action.payload.data.healthFacilities),
-        error: formatGraphQLError(action.payload),
+        healthFacilities: {
+          availableHealthFacilities: parseData(action.payload.data.healthFacilities),
+          isFetching: false,
+          isFetched: true,
+          error: formatGraphQLError(action.payload),
+        },
       };
     case "CLAIM_HEALTH_FACILITIES_ERR":
       return {
         ...state,
-        isFetching: false,
-        error: formatServerError(action.payload),
-      };
+        healthFacilities: {
+          isFetching: false,
+          error: formatServerError(action.payload),
+        },
+    };
     case "CLAIM_MUTATION_REQ":
       return dispatchMutationReq(state, action);
     case "CLAIM_MUTATION_ERR":


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OP-1086

Changes:
- added fetching available HF to Claim Admin Picker. HFs are filtered by available location.
- state is extended with 'healthFacilities'

Notes:
- double use of 'useEffect' may require refactor

Realted:
https://github.com/openimis/openimis-be-location_py/pull/49
https://github.com/openimis/openimis-be-claim_py/pull/68

