### PR TITLE
OP-1307: make status picker always read only in claim detail

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -276,7 +276,7 @@ class ClaimChildPanel extends Component {
       itemFormatters.push(
         (i, idx) => (
           <PublishedComponent
-            readOnly={!forReview && readOnly}
+            readOnly={true}
             pubRef="claim.ApprovalStatusPicker"
             withNull={false}
             withLabel={false}


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-1307

This PR blocks editing of item service status in claim.