### PR TITLE
OTC-1108: insuree picker type changed

### DIFF
--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -59,7 +59,7 @@ class ClaimMasterPanel extends FormPanel {
     this.insureePicker = props.modulesManager.getConf(
       "fe-claim",
       "claimForm.insureePicker",
-      "insuree.InsureeChfIdPicker",
+      "insuree.InsureeNameByChfIdPicker",
     );
   }
 
@@ -140,9 +140,8 @@ class ClaimMasterPanel extends FormPanel {
             <Grid item xs={3} className={classes.item}>
               <PublishedComponent
                 pubRef={this.insureePicker}
-                value={edited.insuree}
-                reset={reset}
-                onChange={(v, s) => this.updateAttribute("insuree", v)}
+                value={edited.insureeName}
+                onChange={(v, s) => this.updateAttribute("insureeName", v)}
                 readOnly={ro}
                 required={true}
               />


### PR DESCRIPTION
**REQUIRED [INSUREE PR](https://github.com/openimis/openimis-fe-insuree_js/pull/65)**
**REQUIRED [BE PR](https://github.com/openimis/openimis-be-claim_py/pull/105)**

[OTC-1108](https://openimis.atlassian.net/browse/OTC-1108)

Changes:
- Use _InsureeNameByChfIdPicker_ instead of _InsureeChfIdPicker_.

[OTC-1108]: https://openimis.atlassian.net/browse/OTC-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ