### PR TITLE
ONI-64: Policy active/inactive status indicator.

### DIFF
--- a/src/components/ClaimMasterPanelExt.js
+++ b/src/components/ClaimMasterPanelExt.js
@@ -4,7 +4,8 @@ import { bindActionCreators } from "redux";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Grid, Typography, Divider } from "@material-ui/core";
 import { PublishedComponent, FormattedMessage, ProgressOrError, TextInput } from "@openimis/fe-core";
-import {clearLastClaimAt, fetchLastClaimAt} from "../actions";
+import { clearLastClaimAt, fetchLastClaimAt } from "../actions";
+import { getTimeDifferenceInDays, getTimeDifferenceInDaysFromToday } from "@openimis/fe-core";
 
 const styles = (theme) => ({
   tableHeader: theme.table.header,
@@ -55,7 +56,6 @@ class ClaimMasterPanelExt extends Component {
 
   getPolicyStatusLabelStyle(timeDelta, classes){
     let policyStatusLabelStyle = null;
-    console.log({policyStatusLabelStyle});
     if (timeDelta >= 0){
       policyStatusLabelStyle = classes.activeLabel;
     }
@@ -67,8 +67,7 @@ class ClaimMasterPanelExt extends Component {
 
   render() {
     const { classes, claim, fetchingLastClaimAt, errorLastClaimAt, fetchedLastClaimAt, lastClaimAt } = this.props;
-    let policyExpireDate = this.props?.currentPolicy?.policyExpireDate ? new Date(this.props?.currentPolicy?.policyExpireDate) : null;
-    let timeDelta = 2;
+    let timeDelta = getTimeDifferenceInDaysFromToday(this.props?.currentPolicy ? this.props?.currentPolicy[0]?.expiryDate : null);
     let policyStatusLabel = this.props.currentPolicy ? this.getPolicyStatusLabel(timeDelta) : "ClaimMasterPanelExt.InsureePolicyEligibilitySummary.header";
     let policyStatusLabelStyle = this.props.currentPolicy ? this.getPolicyStatusLabelStyle(timeDelta, classes) : classes.item;
     return (

--- a/src/components/ClaimMasterPanelExt.js
+++ b/src/components/ClaimMasterPanelExt.js
@@ -9,6 +9,8 @@ import {clearLastClaimAt, fetchLastClaimAt} from "../actions";
 const styles = (theme) => ({
   tableHeader: theme.table.header,
   item: theme.paper.item,
+  inactiveLabel: theme.paper.policyInactive,
+  activeLabel: theme.paper.policyActive,
 });
 
 class ClaimMasterPanelExt extends Component {
@@ -40,13 +42,40 @@ class ClaimMasterPanelExt extends Component {
     this.props.clearLastClaimAt();
   }
 
+  getPolicyStatusLabel(timeDelta){
+    let policyStatusLabel = null;
+    if (timeDelta >= 0){
+      policyStatusLabel = "ClaimMasterPanelExt.InsureePolicyEligibilitySummaryActive.header";
+    }
+    else{
+      policyStatusLabel = "ClaimMasterPanelExt.InsureePolicyEligibilitySummaryInactive.header";
+    }
+    return policyStatusLabel;
+  }
+
+  getPolicyStatusLabelStyle(timeDelta, classes){
+    let policyStatusLabelStyle = null;
+    console.log({policyStatusLabelStyle});
+    if (timeDelta >= 0){
+      policyStatusLabelStyle = classes.activeLabel;
+    }
+    else{
+      policyStatusLabelStyle = classes.inactiveLabel;
+    }
+    return policyStatusLabelStyle;
+  }
+
   render() {
     const { classes, claim, fetchingLastClaimAt, errorLastClaimAt, fetchedLastClaimAt, lastClaimAt } = this.props;
+    let policyExpireDate = this.props?.currentPolicy?.policyExpireDate ? new Date(this.props?.currentPolicy?.policyExpireDate) : null;
+    let timeDelta = 2;
+    let policyStatusLabel = this.props.currentPolicy ? this.getPolicyStatusLabel(timeDelta) : "ClaimMasterPanelExt.InsureePolicyEligibilitySummary.header";
+    let policyStatusLabelStyle = this.props.currentPolicy ? this.getPolicyStatusLabelStyle(timeDelta, classes) : classes.item;
     return (
       <Grid container>
         <Grid item xs={6} className={classes.item}>
-          <Typography className={classes.tableTitle}>
-            <FormattedMessage module="claim" id="ClaimMasterPanelExt.InsureePolicyEligibilitySummary.header" />
+          <Typography className={policyStatusLabelStyle}>
+            <FormattedMessage module="claim" id={policyStatusLabel} />
           </Typography>
           <Divider />
         </Grid>
@@ -111,6 +140,7 @@ const mapStateToProps = (state) => ({
   fetchedLastClaimAt: state.claim.fetchedLastClaimAt,
   lastClaimAt: state.claim.lastClaimAt,
   errorLastClaimAt: state.claim.errorLastClaimAt,
+  currentPolicy: state.policy.policies,
 });
 
 const mapDispatchToProps = (dispatch) => {

--- a/src/components/ClaimMasterPanelExt.js
+++ b/src/components/ClaimMasterPanelExt.js
@@ -5,14 +5,23 @@ import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Grid, Typography, Divider } from "@material-ui/core";
 import { PublishedComponent, FormattedMessage, ProgressOrError, TextInput } from "@openimis/fe-core";
 import { clearLastClaimAt, fetchLastClaimAt } from "../actions";
-import { getTimeDifferenceInDays, getTimeDifferenceInDaysFromToday } from "@openimis/fe-core";
+import { getTimeDifferenceInDaysFromToday } from "@openimis/fe-core";
 
 const styles = (theme) => ({
   tableHeader: theme.table.header,
   item: theme.paper.item,
-  inactiveLabel: theme.paper.policyInactive,
-  activeLabel: theme.paper.policyActive,
+  activeLabel: {
+    padding: 10,
+  },
+  inactiveLabel: {
+    padding: 10,
+    color: "#e20606",
+  },
 });
+
+const ACTIVE_LABEL = "ClaimMasterPanelExt.InsureePolicyEligibilitySummaryActive.header";
+const INACTIVE_LABEL = "ClaimMasterPanelExt.InsureePolicyEligibilitySummaryInactive.header";
+const DEFAULT_LABEL =  "ClaimMasterPanelExt.InsureePolicyEligibilitySummary.header";
 
 class ClaimMasterPanelExt extends Component {
   componentDidMount() {
@@ -43,33 +52,15 @@ class ClaimMasterPanelExt extends Component {
     this.props.clearLastClaimAt();
   }
 
-  getPolicyStatusLabel(timeDelta){
-    let policyStatusLabel = null;
-    if (timeDelta >= 0){
-      policyStatusLabel = "ClaimMasterPanelExt.InsureePolicyEligibilitySummaryActive.header";
-    }
-    else{
-      policyStatusLabel = "ClaimMasterPanelExt.InsureePolicyEligibilitySummaryInactive.header";
-    }
-    return policyStatusLabel;
-  }
+  getPolicyStatusLabel(timeDelta) { return timeDelta >= 0 ? ACTIVE_LABEL : INACTIVE_LABEL; };
 
-  getPolicyStatusLabelStyle(timeDelta, classes){
-    let policyStatusLabelStyle = null;
-    if (timeDelta >= 0){
-      policyStatusLabelStyle = classes.activeLabel;
-    }
-    else{
-      policyStatusLabelStyle = classes.inactiveLabel;
-    }
-    return policyStatusLabelStyle;
-  }
+  getPolicyStatusLabelStyle(timeDelta, classes) { return timeDelta >= 0 ? classes.activeLabel : classes.inactiveLabel; }
 
   render() {
     const { classes, claim, fetchingLastClaimAt, errorLastClaimAt, fetchedLastClaimAt, lastClaimAt } = this.props;
-    let timeDelta = getTimeDifferenceInDaysFromToday(this.props?.currentPolicy ? this.props?.currentPolicy[0]?.expiryDate : null);
-    let policyStatusLabel = this.props.currentPolicy ? this.getPolicyStatusLabel(timeDelta) : "ClaimMasterPanelExt.InsureePolicyEligibilitySummary.header";
-    let policyStatusLabelStyle = this.props.currentPolicy ? this.getPolicyStatusLabelStyle(timeDelta, classes) : classes.item;
+    const timeDelta = getTimeDifferenceInDaysFromToday(this.props.currentPolicy ? this.props.currentPolicy?.[0]?.expiryDate : null);
+    const policyStatusLabel = this.props.currentPolicy ? this.getPolicyStatusLabel(timeDelta) : DEFAULT_LABEL;
+    const policyStatusLabelStyle = this.props.currentPolicy ? this.getPolicyStatusLabelStyle(timeDelta, classes) : classes.item;
     return (
       <Grid container>
         <Grid item xs={6} className={classes.item}>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -206,6 +206,8 @@
   "claim.Feedback.Tristate.0": "No",
   "claim.Feedback.Tristate.1": "Yes",
   "claim.ClaimMasterPanelExt.InsureePolicyEligibilitySummary.header": "Policy Information",
+  "claim.ClaimMasterPanelExt.InsureePolicyEligibilitySummaryActive.header": "Policy Information (Active)",
+  "claim.ClaimMasterPanelExt.InsureePolicyEligibilitySummaryInactive.header": "Policy Information (Inactive)",
   "claim.ClaimMasterPanelExt.InsureeLastVisit.header": "Insuree Last Visit",
   "ClaimMasterPanelExt.InsureeLastVisit.noOtheClaim": "No Other Visit (Claim)",
   "ClaimMasterPanelExt.InsureeLastVisit.thisClaimIsLastVisit": "This is the last visit (Claim)",


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-64
Required PR's: 
https://github.com/openimis/openimis-fe-core_js/pull/140

Changes:
- Changing label of policy section depending on its active/inactive status
- Color is changed as well