### PR TITLE
OP-1491: make status picker disabled if product id not defined

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -294,10 +294,10 @@ export function fetchClaim(mm, claimUuid, forFeedback) {
   } else {
     projections.push(
       "services{" +
-        "id, service {id code name price maximumAmount} qtyProvided, priceAsked, qtyApproved, priceApproved, priceValuated, priceAdjusted, explanation, justification, rejectionReason, status" +
+        "id, product { id, uuid }, service {id code name price maximumAmount} qtyProvided, priceAsked, qtyApproved, priceApproved, priceValuated, priceAdjusted, explanation, justification, rejectionReason, status" +
         "}",
       "items{" +
-        "id, item {id code name price maximumAmount} qtyProvided, priceAsked, qtyApproved, priceApproved, priceValuated, priceAdjusted, explanation, justification, rejectionReason, status" +
+        "id, product { id, uuid }, item {id code name price maximumAmount} qtyProvided, priceAsked, qtyApproved, priceApproved, priceValuated, priceAdjusted, explanation, justification, rejectionReason, status" +
         "}",
     );
   }

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -312,7 +312,6 @@ class ClaimChildPanel extends Component {
       )
     }
 
-
     if (this.showJustificationAtEnter || edited.status !== 2) {
       preHeaders.push("");
       headers.push(`edit.${type}s.justification`);
@@ -330,7 +329,7 @@ class ClaimChildPanel extends Component {
       itemFormatters.push(
         (i, idx) => (
           <PublishedComponent
-            readOnly={true}
+            readOnly={!i.product?.uuid}
             pubRef="claim.ApprovalStatusPicker"
             withNull={false}
             withLabel={false}


### PR DESCRIPTION
[OP-1491](https://openimis.atlassian.net/browse/OP-1491)

Changes:
- Claim item and service status cannot be changed during review only if product in item/service is not defined.

[OP-1491]: https://openimis.atlassian.net/browse/OP-1491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ