### PR TITLE
OP-1454: parse to decimal before sending filters to query

### DIFF
--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -380,7 +380,7 @@ class Details extends Component {
                 {
                   id: "claimedAbove",
                   value: !v ? null : v,
-                  filter: !!v ? `claimed_Gte: ${v}` : null,
+                  filter: !!v ? `claimed_Gte: "${parseFloat(v)}"` : null,
                 },
               ])
             }
@@ -397,7 +397,7 @@ class Details extends Component {
                 {
                   id: "claimedUnder",
                   value: !v ? null : v,
-                  filter: !!v ? `claimed_Lte: ${v}` : null,
+                  filter: !!v ? `claimed_Lte: "${parseFloat(v)}"` : null,
                 },
               ])
             }


### PR DESCRIPTION
[OP-1454](https://openimis.atlassian.net/browse/OP-1454)

Changes:
- Parse ‘Claimed More/Less Than’ to decimal before sending filters.

[OP-1454]: https://openimis.atlassian.net/browse/OP-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ