### PR TITLE
ONI-146: Claimed date set to current date setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ None
     },
   }
 - `claimForm.showOrdinalNumber`, show "number" column as a first column in claim searcher and item/services table. Default false.
+- `claimForm.isClaimedDateFixed`, set Date Claimed to current date and set field to read only while creating new claim. Default false.

--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -87,6 +87,11 @@ class ClaimMasterPanel extends FormPanel {
       "claimForm.isCareTypeMandatory",
       false,
     );
+    this.isClaimedDateFixed = props.modulesManager.getConf(
+      "fe-claim",
+      "claimForm.isClaimedDateFixed",
+      false,
+    );
     this.EMPTY_STRING = ""
   }
 
@@ -224,12 +229,12 @@ class ClaimMasterPanel extends FormPanel {
             <Grid item xs={2} className={classes.item}>
               <PublishedComponent
                 pubRef="core.DatePicker"
-                value={edited.dateClaimed}
+                value={edited.dateClaimed ?? new Date()}
                 module="claim"
                 label="claimedDate"
                 reset={reset}
                 onChange={(d) => this.updateAttribute("dateClaimed", d)}
-                readOnly={ro}
+                readOnly={this.isClaimedDateFixed ?? ro}
                 required={true}
                 minDate={!!edited.dateTo ? edited.dateTo : edited.dateFrom}
               />


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-146

Changes:
- Default value of date claimed set to current date
- Added setting to make this field read only, allowing only current date as date of new claims.