### PR TITLE
ONI-151: Additional conditions for reject/accept all rendering.

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -123,6 +123,15 @@ class ClaimChildPanel extends Component {
     this._onEditedChanged(data);
   };
 
+  _checkIfItemsServicesExist = (type, edited) => {
+    if (type==="item"){
+      return Array.isArray(edited.items) ? !edited.items.length==0 : false;
+    }
+    else{
+      return Array.isArray(edited.services) ? !edited.services.length==0 : false;
+    }
+  };
+
   formatRejectedReason = (i, idx) => {
     if (i.status === 1) return null;
     return (
@@ -294,24 +303,28 @@ class ClaimChildPanel extends Component {
           onChange={(v) => this._onChange(idx, "priceValuated", v)}
         />
       ));
-      preHeaders.push(
-        withTooltip(
-          <IconButton onClick={this.rejectAllOnClick}>
-            <ThumbDown />
-          </IconButton>,
-          formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.rejectAll")
-        )
-      )
-      preHeaders.push(
-        withTooltip(
-          <IconButton onClick={this.approveAllOnClick}>
-            <ThumbUp />
-          </IconButton>,
-          formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.approveAll")
-        )
-      )
     }
 
+    if (!!forReview && edited.status == 4){
+      if (this._checkIfItemsServicesExist(this.props.type, edited)){
+        preHeaders.push(
+          withTooltip(
+            <IconButton onClick={this.rejectAllOnClick}>
+              <ThumbDown />
+            </IconButton>,
+            formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.rejectAll")
+          )
+        )
+        preHeaders.push(
+          withTooltip(
+            <IconButton onClick={this.approveAllOnClick}>
+              <ThumbUp />
+            </IconButton>,
+            formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.approveAll")
+          )
+        )
+      }
+    }
     if (this.showJustificationAtEnter || edited.status !== 2) {
       preHeaders.push("");
       headers.push(`edit.${type}s.justification`);


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-151

Changes:
- Reject/accept all buttons are now only rendered for claim in 'checked' status.
- They are only rendered if there are any services/items in given claim.