### PR TITLE
OP-1539: set default max amount to 1m

### DIFF
--- a/src/pages/ReviewsPage.js
+++ b/src/pages/ReviewsPage.js
@@ -306,6 +306,10 @@ class ReviewsPage extends Component {
           "value": 4,
           "filter": "status: 4",
         },
+        claimedUnder: {
+          "value": 1000000,
+          "filter": "claimed_Lte: \"1000000\"",
+        },
       }),
     };
   }
@@ -639,8 +643,6 @@ class ReviewsPage extends Component {
         action: this.processSelected,
       });
     }
-
-    //actions.push(...extra_action);
 
     return (
       <div className={classes.page}>


### PR DESCRIPTION
[OP-1539](https://openimis.atlassian.net/browse/OP-1539)

Changes:
- Set default max 'Claimed Less Than' to 1 000 000. Value can be changed through the config.

![image](https://github.com/openimis/openimis-fe-claim_js/assets/109145288/bc10c6b8-dc27-4b92-ba25-a1644a5ecc09)


[OP-1539]: https://openimis.atlassian.net/browse/OP-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ