### PR TITLE
ONI-95: table with claims related to insuree

### DIFF
--- a/src/components/ClaimInsureeSummary.js
+++ b/src/components/ClaimInsureeSummary.js
@@ -1,0 +1,106 @@
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useIntl } from "react-intl";
+
+import { Typography, Grid, Paper, IconButton, Tooltip } from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+import AddIcon from "@material-ui/icons/Add";
+import VisibilityIcon from "@material-ui/icons/Visibility";
+
+import { useModulesManager, useTranslations, Table, useHistory, historyPush, formatAmount } from "@openimis/fe-core";
+import { fetchClaimSummaries } from "../actions";
+import { MODULE_NAME } from "../constants";
+
+const useStyles = makeStyles((theme) => ({
+  page: theme.page,
+  paper: theme.paper.paper,
+  item: theme.paper.item,
+  paperHeader: theme.paper.header,
+  tableTitle: theme.table.title,
+}));
+
+const CLAIMS_HEADERS = [
+  "claimSummaries.code",
+  "claimSummaries.claimedDate",
+  "ClaimFilter.healthFacility",
+  "claimSummaries.processedDate",
+  "claimSummaries.feedbackStatus",
+  "claimSummaries.reviewStatus",
+  "claimSummaries.claimed",
+  "claimSummaries.approved",
+  "claimSummaries.claimStatus",
+  "emptyLabel",
+];
+
+const ClaimInsureeSummary = ({ insuree }) => {
+  const dispatch = useDispatch();
+  const modulesManager = useModulesManager();
+  const classes = useStyles();
+  const history = useHistory();
+  const intl = useIntl();
+  const { formatMessage, formatMessageWithValues, formatDateFromISO } = useTranslations(MODULE_NAME, modulesManager);
+
+  const { claims, fetchingClaims, errorClaims, claimsPageInfo } = useSelector((store) => store.claim);
+
+  const onCreateNewClaim = () => historyPush(modulesManager, history, "claim.route.healthFacilities");
+
+  const goToClaim = (claim) => historyPush(modulesManager, history, "claim.route.claimEdit", [claim.uuid]);
+
+  const ITEMS_FORMATTERS = [
+    (claim) => claim?.code,
+    (claim) => formatDateFromISO(claim?.dateClaimed),
+    (claim) => `${claim?.healthFacility?.code} ${claim?.healthFacility?.name}`,
+    (claim) => formatDateFromISO(claim?.dateProcessed),
+    (claim) => formatMessage(`feedbackStatus.${claim?.feedbackStatus}`),
+    (claim) => formatMessage(`reviewStatus.${claim?.reviewStatus}`),
+    (claim) => formatAmount(intl, claim?.claimed),
+    (claim) => formatAmount(intl, claim?.approved),
+    (claim) => formatMessage(`claimStatus.${claim?.status}`),
+    (claim) => (
+      <Tooltip title={formatMessage("ClaimMasterPanelExt.InsureeInfo.goToClaim.Button")}>
+        <IconButton onClick={() => goToClaim(claim)}>
+          <VisibilityIcon />
+        </IconButton>
+      </Tooltip>
+    ),
+  ];
+
+  useEffect(() => {
+    if (!insuree) return;
+
+    const filters = [`insuree_ChfId: "${insuree.chfId}", orderBy: ["-dateClaimed"]`];
+    dispatch(fetchClaimSummaries(modulesManager, filters));
+  }, [insuree]);
+
+  return (
+    <Paper className={classes.paper}>
+      <Grid container alignItems="center" direction="row" className={classes.paperHeader}>
+        <Grid item xs={8}>
+          <Typography className={classes.tableTitle}>
+            {formatMessageWithValues("claimSummaries", { count: claimsPageInfo?.totalCount })}
+          </Typography>
+        </Grid>
+        <Grid item xs={4}>
+          <Grid className={classes.item} container justify="flex-end">
+            <Tooltip title={formatMessage("newClaim.tooltip")}>
+              <IconButton onClick={onCreateNewClaim}>
+                <AddIcon />
+              </IconButton>
+            </Tooltip>
+          </Grid>
+        </Grid>
+      </Grid>
+      <Table
+        module="claim"
+        error={errorClaims}
+        fetching={fetchingClaims}
+        headers={CLAIMS_HEADERS}
+        itemFormatters={ITEMS_FORMATTERS}
+        items={claims}
+        withPagination={false}
+      />
+    </Paper>
+  );
+};
+
+export default ClaimInsureeSummary;

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import ClaimPercentageReferralsReport from "./reports/ClaimPercentageReferralsRe
 import ClaimsOverviewReport from "./reports/ClaimsOverviewReport";
 import ClaimHistoryReport from "./reports/ClaimHistoryReport";
 import ClaimsPrimaryOperationalIndicators from "./reports/ClaimsPrimaryOperationalIndicators";
+import ClaimInsureeSummary from "./components/ClaimInsureeSummary";
 
 const ROUTE_HEALTH_FACILITIES = "claim/healthFacilities";
 const ROUTE_CLAIM_EDIT = "claim/healthFacilities/claim";
@@ -175,6 +176,7 @@ const DEFAULT_CONFIG = {
   ],
   "core.MainMenu": [ClaimMainMenu],
   "claim.MasterPanel": [ClaimMasterPanelExt],
+  "insuree.ProfilePage.insureeClaims": [ClaimInsureeSummary],
 };
 
 export const ClaimModule = (cfg) => {


### PR DESCRIPTION
[ONI-95](https://openimis.atlassian.net/browse/ONI-95)

[RELATED PR #1](https://github.com/openimis/openimis-fe-policy_js/pull/62)
[RELATED PR #2](https://github.com/openimis/openimis-fe-insuree_js/pull/90)

Changes:
- Add component which displays claim related to provided insuree.

[ONI-95]: https://openimis.atlassian.net/browse/ONI-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ