### PR TITLE
OP-1705: fix visit date filters

### DIFF
--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -416,7 +416,7 @@ class Details extends Component {
                     {
                       id: "visitDateFrom",
                       value: d,
-                      filter: !!d ? `dateFrom: "${d}"` : null,
+                      filter: !!d ? `dateFrom_Gte: "${d}"` : null,
                     },
                   ])
                 }
@@ -433,7 +433,7 @@ class Details extends Component {
                     {
                       id: "visitDateTo",
                       value: d,
-                      filter: !!d ? `dateTo: "${d}"` : null,
+                      filter: !!d ? `dateTo_Lte: "${d}"` : null,
                     },
                   ])
                 }

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -193,16 +193,24 @@ class ClaimSearcher extends Component {
   };
 
   sorts = () => {
-    var result = [
+    const result = [];
+
+    if (this.showOrdinalNumber) {
+      result.push(null);
+    }
+
+    result.push(
       ["code", true],
       [this.props.modulesManager.getRef("location.HealthFacilityPicker.sort"), true],
       [this.props.modulesManager.getRef("insuree.InsureePicker.sort"), true],
-      ["dateClaimed", false],
+      ["dateClaimed", true],
+      null,
       null,
       null,
       ["claimed", false],
       ["approved", false],
-    ];
+    );
+
     if (this.claimAttachments) {
       result.push(null);
     }
@@ -347,7 +355,7 @@ class ClaimSearcher extends Component {
           sorts={this.sorts}
           onDoubleClick={onDoubleClick}
           actionsContributionKey={actionsContributionKey}
-          showOrdinalNumber = {this.showOrdinalNumber}
+          showOrdinalNumber={this.showOrdinalNumber}
         />
       </Fragment>
     );


### PR DESCRIPTION
[OP-1705](https://openimis.atlassian.net/browse/OP-1705)

Changes:
- Adjusted the "Visit Date From" and "Visit Date To" fields to function accurately as a date range filter, ensuring they search within the specified timeframe rather than targeting the exact dates provided.
- Quick fix on sorting if oridinal number column is visible.

[OP-1705]: https://openimis.atlassian.net/browse/OP-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ