### PR TITLE
OP-1725: remove null/empty option from dropdown

### DIFF
--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -250,7 +250,7 @@ class ClaimMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="claim.CareTypePicker"
                 name="careType"
-                withNull={!this.isCareTypeMandatory}
+                withNull={false}
                 value={edited.careType}
                 reset={reset}
                 onChange={(value) => this.updateAttribute("careType", value)}


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:
- Remove the 'none/null' option from the dropdown menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ