### PR TITLE
ONI-134: add info about items/services to the table header

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import _ from "lodash";
 
-import { Paper, Box, IconButton } from "@material-ui/core";
+import { Paper, Box, IconButton, Typography, Grid } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { ThumbUp, ThumbDown } from "@material-ui/icons";
 
@@ -27,7 +27,6 @@ import { claimedAmount, approvedAmount } from "../helpers/amounts";
 const styles = (theme) => ({
   paper: theme.paper.paper,
 });
-
 
 class ClaimChildPanel extends Component {
   state = {
@@ -133,7 +132,6 @@ class ClaimChildPanel extends Component {
     this._onEditedChanged(data);
   };
 
-
   _onDelete = (idx) => {
     const data = [...this.state.data];
     data.splice(idx, 1);
@@ -195,6 +193,58 @@ class ClaimChildPanel extends Component {
     });
   };
 
+  extendHeader = () => {
+    const { intl, type, edited, forReview } = this.props;
+
+    const totalClaimed = _.round(
+      this.state.data.reduce((sum, r) => sum + claimedAmount(r), 0),
+      2,
+    );
+    const totalApproved = _.round(
+      this.state.data.reduce((sum, r) => sum + approvedAmount(r), 0),
+      2,
+    );
+
+    return (
+      <>
+        {totalClaimed > 0 && (
+          <Typography>
+            {formatMessageWithValues(intl, "claim", `edit.${type}s.totalClaimed`, {
+              totalClaimed: formatAmount(intl, totalClaimed),
+            })}
+          </Typography>
+        )}
+        {totalClaimed > 0 && (
+          <Typography>
+            {formatMessageWithValues(intl, "claim", `edit.${type}s.totalApproved`, {
+              totalApproved: formatAmount(intl, totalApproved),
+            })}
+          </Typography>
+        )}
+        {
+          <Grid>
+            {!!forReview && edited.status == 4 && this._checkIfItemsServicesExist(type, edited) && (
+              <>
+                {withTooltip(
+                  <IconButton onClick={this.rejectAllOnClick}>
+                    <ThumbDown />
+                  </IconButton>,
+                  formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.rejectAll"),
+                )}
+                {withTooltip(
+                  <IconButton onClick={this.approveAllOnClick}>
+                    <ThumbUp />
+                  </IconButton>,
+                  formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.approveAll"),
+                )}
+              </>
+            )}
+          </Grid>
+        }
+      </>
+    );
+  };
+
   render() {
     const { intl, classes, edited, type, picker, forReview, fetchingPricelist, readOnly = false } = this.props;
     if (!edited) return null;
@@ -213,16 +263,6 @@ class ClaimChildPanel extends Component {
       this.state.data.reduce((sum, r) => sum + approvedAmount(r), 0),
       2,
     );
-    let preHeaders = [
-      "\u200b",
-      "",
-      totalClaimed > 0
-        ? formatMessageWithValues(intl, "claim", `edit.${type}s.totalClaimed`, {
-          totalClaimed: formatAmount(intl, totalClaimed),
-        })
-        : "",
-      "",
-    ];
     let headers = [
       `edit.${type}s.${type}`,
       `edit.${type}s.quantity`,
@@ -290,17 +330,6 @@ class ClaimChildPanel extends Component {
       ),
     ];
     if (!!forReview || edited.status !== 2) {
-      if (!this.fixedPricesAtReview) {
-        preHeaders.push("");
-      }
-      preHeaders.push(
-        totalClaimed > 0
-          ? formatMessageWithValues(intl, "claim", `edit.${type}s.totalApproved`, {
-            totalApproved: formatAmount(intl, totalApproved),
-          })
-          : "",
-      );
-
       headers.push(`edit.${type}s.appQuantity`);
       itemFormatters.push((i, idx) => (
         <NumberInput
@@ -333,28 +362,7 @@ class ClaimChildPanel extends Component {
       ));
     }
 
-    if (!!forReview && edited.status == 4){
-      if (this._checkIfItemsServicesExist(this.props.type, edited)){
-        preHeaders.push(
-          withTooltip(
-            <IconButton onClick={this.rejectAllOnClick}>
-              <ThumbDown />
-            </IconButton>,
-            formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.rejectAll")
-          )
-        )
-        preHeaders.push(
-          withTooltip(
-            <IconButton onClick={this.approveAllOnClick}>
-              <ThumbUp />
-            </IconButton>,
-            formatMessage(this.props.intl, "claim", "ClaimChildPanel.review.approveAll")
-          )
-        )
-      }
-    }
     if (this.showJustificationAtEnter || edited.status !== 2) {
-      preHeaders.push("");
       headers.push(`edit.${type}s.justification`);
       itemFormatters.push((i, idx) => (
         <TextInput
@@ -365,7 +373,6 @@ class ClaimChildPanel extends Component {
       ));
     }
     if (!!forReview || edited.status !== 2) {
-      preHeaders.push("", "");
       headers.push(`edit.${type}s.status`, `edit.${type}s.rejectionReason`);
       itemFormatters.push(
         (i, idx) => (
@@ -390,16 +397,16 @@ class ClaimChildPanel extends Component {
         <Table
           module="claim"
           header={header}
-          preHeaders={preHeaders}
+          extendHeader={this.extendHeader}
           headers={headers}
           itemFormatters={itemFormatters}
           items={!fetchingPricelist ? this.state.data : []}
           onDelete={!forReview && !readOnly && this._onDelete}
-          showOrdinalNumber = {this.showOrdinalNumber}
+          showOrdinalNumber={this.showOrdinalNumber}
         />
       </Paper>
     );
-}
+  }
 }
 
 const mapStateToProps = (state, props) => ({

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -255,14 +255,6 @@ class ClaimChildPanel extends Component {
         </Paper>
       );
     }
-    const totalClaimed = _.round(
-      this.state.data.reduce((sum, r) => sum + claimedAmount(r), 0),
-      2,
-    );
-    const totalApproved = _.round(
-      this.state.data.reduce((sum, r) => sum + approvedAmount(r), 0),
-      2,
-    );
     let headers = [
       `edit.${type}s.${type}`,
       `edit.${type}s.quantity`,


### PR DESCRIPTION
[ONI-134](https://openimis.atlassian.net/browse/ONI-134)

[REQUIRED PR](https://github.com/openimis/openimis-fe-core_js/pull/190)

Changes:
- Enhance the Services/Items Table by appending extra information to the headers.
![image](https://github.com/openimis/openimis-fe-claim_js/assets/109145288/b3b27fe9-4bc7-4a0c-b1a9-92ea1f4df73c)


[ONI-134]: https://openimis.atlassian.net/browse/ONI-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ