### PR TITLE
OP-1829: disable delete button on empty row

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -394,6 +394,7 @@ class ClaimChildPanel extends Component {
           itemFormatters={itemFormatters}
           items={!fetchingPricelist ? this.state.data : []}
           onDelete={!forReview && !readOnly && this._onDelete}
+          disableDeleteOnEmptyRow
           showOrdinalNumber={this.showOrdinalNumber}
         />
       </Paper>


### PR DESCRIPTION
[OP-1829](https://openimis.atlassian.net/browse/OP-1829)

[REQUIRED](https://github.com/openimis/openimis-fe-core_js/pull/202)

Changes:
- Disable the delete button on empty row in claim services/items table.
![image](https://github.com/openimis/openimis-fe-claim_js/assets/109145288/f0f7a764-8334-4df9-8541-36fc7d58a3eb)


[OP-1829]: https://openimis.atlassian.net/browse/OP-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ