### PR TITLE
OP-1830: price of service/item could not be negative

### DIFF
--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -256,9 +256,7 @@ class ClaimForm extends Component {
       return false;
     }
 
-    if (forReview && qtyProvided < detail.qtyApproved) {
-      return false;
-    }
+    if (forReview && qtyProvided < detail.qtyApproved) return false;
 
     return true;
   };

--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -238,24 +238,28 @@ class ClaimForm extends Component {
     );
   };
 
-  canSaveDetail = (d, type, forReview) => {
-    if (!d[type]) return false;
-    if (d.qtyProvided === null || d.qtyProvided === undefined || d.qtyProvided === "" || d.qtyProvided <= 0)
-      return false;
-    if (d.priceAsked === null || d.priceAsked === undefined || d.priceAsked === "") return false;
+  canSaveDetail = (detail, type, forReview) => {
+    if (!detail[type]) return false;
+
+    const qtyProvided = Number(detail.qtyProvided);
+    if (isNaN(qtyProvided) || qtyProvided <= 0) return false;
+
+    const priceAsked = Number(detail.priceAsked);
+    if (isNaN(priceAsked) || priceAsked < 0) return false;
+
     if (
       this.explanationRequiredIfQuantityAboveThreshold &&
       type === "service" &&
-      !d.explanation &&
-      d.qtyProvided > this.quantityExplanationThreshold
+      !detail.explanation &&
+      qtyProvided > this.quantityExplanationThreshold
     ) {
       return false;
     }
-    if (forReview) {
-      if (d.qtyProvided < d.qtyApproved) {
-        return false;
-      }
+
+    if (forReview && qtyProvided < detail.qtyApproved) {
+      return false;
     }
+
     return true;
   };
 


### PR DESCRIPTION
[OP-1830](https://openimis.atlassian.net/browse/OP-1830)

[REQUIRED](https://github.com/openimis/openimis-fe-core_js/pull/203)

Changes:
- Saving disabled if price of service/item < 0.
- Complexity of `canSaveDetail` has been reduced.

[OP-1830]: https://openimis.atlassian.net/browse/OP-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ