### PR TITLE
OP-1840: add attachment header, improve confirmation messages, clear …

### DIFF
--- a/src/components/AttachmentsDialog.js
+++ b/src/components/AttachmentsDialog.js
@@ -72,7 +72,7 @@ class AttachmentsDialog extends Component {
     if (!_.isEqual(prevProps.claimAttachments, this.props.claimAttachments)) {
       var claimAttachments = [...(this.props.claimAttachments || [])];
       if (!this.props.readOnly && this.props.rights.includes(RIGHT_ADD)) {
-        claimAttachments.push({});
+        claimAttachments.push({ title: "", type: "" });
       }
       this.setState({ claimAttachments, updatedAttachments: new Set() });
     } else if (!_.isEqual(prevProps.claim, this.props.claim) && !!this.props.claim && !!this.props.claim.uuid) {
@@ -117,7 +117,7 @@ class AttachmentsDialog extends Component {
       this.props.deleteAttachment(
         this.state.attachmentToDelete,
         formatMessageWithValues(this.props.intl, "claim", "claim.ClaimAttachment.delete.mutationLabel", {
-          file: `${this.state.attachmentToDelete.title} ${
+          file: `${this.state.attachmentToDelete.title ? `${this.state.attachmentToDelete.title}` : ""} ${
             this.state.attachmentToDelete.filename ? `(${this.state.attachmentToDelete.filename})` : ""
           }`,
           code: `${this.props.claim.code}`,
@@ -186,7 +186,7 @@ class AttachmentsDialog extends Component {
         .createAttachment(
           { ...attachment, claimUuid: this.state.claimUuid },
           formatMessageWithValues(this.props.intl, "claim", "claim.ClaimAttachment.create.mutationLabel", {
-            file: `${attachment.title} ${filename}`,
+            file: `${attachment.title || ""} ${filename}`,
             code: `${this.props.claim.code}`,
           }),
         )
@@ -217,7 +217,7 @@ class AttachmentsDialog extends Component {
     this.props.updateAttachment(
       attachment,
       formatMessageWithValues(this.props.intl, "claim", "claim.ClaimAttachment.update.mutationLabel", {
-        file: `${attachment.title} ${filename}`,
+        file: `${attachment.title || ""} ${filename}`,
         code: `${this.props.claim.code}`,
       }),
     );

--- a/src/components/AttachmentsDialog.js
+++ b/src/components/AttachmentsDialog.js
@@ -114,12 +114,12 @@ class AttachmentsDialog extends Component {
       !!this.props.confirmed &&
       !!this.state.attachmentToDelete
     ) {
+      const title = this.state.attachmentToDelete.title ? `${this.state.attachmentToDelete.title}` : "";
+      const filename = this.state.attachmentToDelete.filename ? `(${this.state.attachmentToDelete.filename})` : "";
       this.props.deleteAttachment(
         this.state.attachmentToDelete,
         formatMessageWithValues(this.props.intl, "claim", "claim.ClaimAttachment.delete.mutationLabel", {
-          file: `${this.state.attachmentToDelete.title ? `${this.state.attachmentToDelete.title}` : ""} ${
-            this.state.attachmentToDelete.filename ? `(${this.state.attachmentToDelete.filename})` : ""
-          }`,
+          file: `${title} ${filename}`,
           code: `${this.props.claim.code}`,
         }),
       );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -246,7 +246,7 @@
   "claim.claimAttachment.predefinedType": "Predefined Type",
   "claim.claimAttachment.title": "Title",
   "claim.claimAttachment.date": "Date",
-  "claim.claimAttachment.fileName": " ",
+  "claim.claimAttachment.fileName": "Attachment",
   "claim.claimAttachment.action": " ",
   "claim.deleteClaimAttachment.confirm.title": "Delete Claim Attachment",
   "claim.deleteClaimAttachment.confirm.message": "Are you sure you want to delete claim attachment {file}?",


### PR DESCRIPTION
…inputs after deletion

[OP-1840](https://openimis.atlassian.net/browse/OP-1840)

Changes:
- Add 'Attachment' header to the column with attachments (urls, files).
- When deleting an attachment, clear the empty row inputs.
- When deleting an attachment, fix confirmation messages by omitting not provided values.
- Lokalise key updated.

[OP-1840]: https://openimis.atlassian.net/browse/OP-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ