### PR TITLE
disable unecessary field in searcher OP-2554 

### DIFF
--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from "redux";
 import _ from "lodash";
 import _debounce from "lodash/debounce";
 import { injectIntl } from "react-intl";
+import { RIGHT_CLAIMREVIEW } from "../constants";
 
 import { Grid, Divider, Checkbox, FormControlLabel } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -252,6 +253,7 @@ class Head extends Component {
 }
 
 const mapStateToProps = (state) => ({
+  rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
   userHealthFacilityId: state.core.user.i_user.health_facility_id,
   claimFilter: state.claim.claimFilter,
   servicesPricelists: !!state.medical_pricelist ? state.medical_pricelist.servicesPricelists : {},
@@ -289,7 +291,7 @@ class Details extends Component {
   };
 
   render() {
-    const { intl, classes, filters, onChangeFilters, filterPaneContributionsKey = null, FilterExt } = this.props;
+    const { intl, classes, filters, onChangeFilters, filterPaneContributionsKey = null, FilterExt, } = this.props;
     return (
       <Grid container className={classes.form}>
         <Grid item xs={1} className={classes.item}>
@@ -487,6 +489,7 @@ class Details extends Component {
         <Grid item xs={3}>
           <Grid container>
             <Grid item xs={6} className={classes.item}>
+              {this.props.rights.includes(RIGHT_CLAIMREVIEW) && (
               <PublishedComponent
                 pubRef="core.DatePicker"
                 value={(filters["processedDateFrom"] && filters["processedDateFrom"]["value"]) || null}
@@ -502,6 +505,7 @@ class Details extends Component {
                   ])
                 }
               />
+              )}
             </Grid>
             <Grid item xs={6} className={classes.item}>
               <PublishedComponent
@@ -593,23 +597,24 @@ class Details extends Component {
           <PublishedComponent
             pubRef="claim.CareTypePicker"
             name="careType"
-            value={(filters["careType"] && filters["careType"]["value"]) || null}
-            onChange={(value) => {
+            value={filters["careType"] && filters["careType"]["value"] || null}
+            onChange={(value) =>{
               onChangeFilters([
                 {
                   id: "careType",
                   value: value,
                   filter: !!value ? `careType: "${value}"` : null,
                 },
-              ]);
-            }}
+              ])
+            }
+            }
           />
         </Grid>
         <Grid item xs={1} className={classes.item}>
           <PublishedComponent
             pubRef="claim.AttachmentStatusPicker"
             name="attachmentStatus"
-            value={(filters["attachmentStatus"] && filters["attachmentStatus"]["value"]) || null}
+            value={filters["attachmentStatus"] && filters["attachmentStatus"]["value"] || null}
             onChange={(value) =>
               onChangeFilters([
                 {
@@ -648,7 +653,7 @@ class Details extends Component {
                   control={
                     <Checkbox
                       color="primary"
-                      checked={(filters["showRestored"] && filters["showRestored"]["value"]) || false}
+                      checked={filters["showRestored"] && filters["showRestored"]["value"] || false}
                       onChange={(event) =>
                         onChangeFilters([
                           {
@@ -666,6 +671,8 @@ class Details extends Component {
             }
           />
         </Grid>
+
+
         <Contributions
           filters={filters}
           onChangeFilters={onChangeFilters}
@@ -693,13 +700,15 @@ class Details extends Component {
   }
 }
 
+const BoundDetails = connect(mapStateToProps, mapDispatchToProps)(Details);
+
 class ClaimFilter extends Component {
   render() {
     const { classes } = this.props;
     return (
       <form className={classes.container} noValidate autoComplete="off">
         <BoundHead {...this.props} />
-        <Details {...this.props} />
+        <BoundDetails {...this.props} />
       </form>
     );
   }

--- a/src/components/ClaimFilter.js
+++ b/src/components/ClaimFilter.js
@@ -486,46 +486,46 @@ class Details extends Component {
             </Grid>
           </Grid>
         </Grid>
-        <Grid item xs={3}>
-          <Grid container>
-            <Grid item xs={6} className={classes.item}>
-              {this.props.rights.includes(RIGHT_CLAIMREVIEW) && (
-              <PublishedComponent
-                pubRef="core.DatePicker"
-                value={(filters["processedDateFrom"] && filters["processedDateFrom"]["value"]) || null}
-                module="claim"
-                label="ClaimFilter.processedDateFrom"
-                onChange={(d) =>
-                  onChangeFilters([
-                    {
-                      id: "processedDateFrom",
-                      value: d,
-                      filter: !!d ? `dateProcessed_Gte: "${d}"` : null,
-                    },
-                  ])
-                }
-              />
-              )}
-            </Grid>
-            <Grid item xs={6} className={classes.item}>
-              <PublishedComponent
-                pubRef="core.DatePicker"
-                value={(filters["processedDateTo"] && filters["processedDateTo"]["value"]) || null}
-                module="claim"
-                label="ClaimFilter.processedDateTo"
-                onChange={(d) =>
-                  onChangeFilters([
-                    {
-                      id: "processedDateTo",
-                      value: d,
-                      filter: !!d ? `dateProcessed_Lte: "${d}"` : null,
-                    },
-                  ])
-                }
-              />
+        {!this.props.rights.includes(RIGHT_CLAIMREVIEW) && (
+          <Grid item xs={3}>
+            <Grid container>
+              <Grid item xs={6} className={classes.item}>
+                <PublishedComponent
+                  pubRef="core.DatePicker"
+                  value={(filters["processedDateFrom"] && filters["processedDateFrom"]["value"]) || null}
+                  module="claim"
+                  label="ClaimFilter.processedDateFrom"
+                  onChange={(d) =>
+                    onChangeFilters([
+                      {
+                        id: "processedDateFrom",
+                        value: d,
+                        filter: !!d ? `dateProcessed_Gte: "${d}"` : null,
+                      },
+                    ])
+                  }
+                />
+              </Grid>
+              <Grid item xs={6} className={classes.item}>
+                <PublishedComponent
+                  pubRef="core.DatePicker"
+                  value={(filters["processedDateTo"] && filters["processedDateTo"]["value"]) || null}
+                  module="claim"
+                  label="ClaimFilter.processedDateTo"
+                  onChange={(d) =>
+                    onChangeFilters([
+                      {
+                        id: "processedDateTo",
+                        value: d,
+                        filter: !!d ? `dateProcessed_Lte: "${d}"` : null,
+                      },
+                    ])
+                  }
+                />
+              </Grid>
             </Grid>
           </Grid>
-        </Grid>
+        )}
         <Grid item xs={3} className={classes.item}>
           <PublishedComponent
             pubRef="medical.ServicePicker"

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -10,6 +10,7 @@ import TabIcon from "@material-ui/icons/Tab";
 import CheckIcon from "@material-ui/icons/Check";
 import { Searcher } from "@openimis/fe-core";
 import ClaimFilter from "./ClaimFilter";
+import { RIGHT_CLAIMREVIEW } from "../constants";
 import {
   withModulesManager,
   formatMessageWithValues,
@@ -38,7 +39,6 @@ class ClaimSearcher extends Component {
       "claimFilter.rowsPerPageOptions",
       [10, 20, 50, 100],
     );
-    this.columns = props.modulesManager.getConf("fe-claim", "columns", {});
     this.defaultPageSize = props.modulesManager.getConf("fe-claim", "claimFilter.defaultPageSize", 10);
     this.highlightAmount = parseInt(props.modulesManager.getConf("fe-claim", "claimFilter.highlightAmount", 0));
     this.highlightAltInsurees = props.modulesManager.getConf("fe-claim", "claimFilter.highlightAltInsurees", true);
@@ -46,6 +46,7 @@ class ClaimSearcher extends Component {
     this.extFields = props.modulesManager.getConf("fe-claim", "extFields", []);
     this.showOrdinalNumber = props.modulesManager.getConf("fe-claim", "claimForm.showOrdinalNumber", false);
     this.showPreAuthorization = props.modulesManager.getConf("fe-claim", "showPreAuthorization", false);
+    this.columns = this.props.modulesManager.getConf("fe-claim", "columns", {});
   }
 
   canSelectAll = (selection) =>
@@ -121,6 +122,7 @@ class ClaimSearcher extends Component {
                 claimed: (
                   <b>
                     {formatAmount(
+                      this.props.modulesManager,
                       this.props.intl,
                       selection.reduce((acc, v) => {
                         if (v.claimed) {
@@ -143,6 +145,7 @@ class ClaimSearcher extends Component {
                 approved: (
                   <b>
                     {formatAmount(
+                      this.props.modulesManager,
                       this.props.intl,
                       selection.reduce((acc, v) => {
                         if (v.approved) {
@@ -176,9 +179,9 @@ class ClaimSearcher extends Component {
       "claimSummaries.healthFacility",
       "claimSummaries.insuree",
       "claimSummaries.claimedDate",
-      this.columns?.processedDate !== "H" ? "claimSummaries.processedDate" : null,
-      "claimSummaries.feedbackStatus",
-      "claimSummaries.reviewStatus",
+      this.props.rights.includes(RIGHT_CLAIMREVIEW) ? "claimSummaries.processedDate" : null,
+      this.columns.feedbackStatus !== "H" ? "claimSummaries.feedbackStatus" : null,
+      this.columns.reviewStatus !== "H" ? "claimSummaries.reviewStatus" : null,
       "claimSummaries.claimed",
       "claimSummaries.approved",
       "claimSummaries.claimStatus",
@@ -245,11 +248,11 @@ class ClaimSearcher extends Component {
       ),
       (c) => <PublishedComponent readOnly={true} pubRef="insuree.InsureePicker" withLabel={false} value={c.insuree} />,
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateClaimed),
-      this.columns?.processedDate !== "H" ? (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed) : null,
-      (c) => this.feedbackColFormatter(c),
-      (c) => this.reviewColFormatter(c),
-      (c) => formatAmount(this.props.intl, c.claimed),
-      (c) => formatAmount(this.props.intl, c.approved),
+      this.props.rights.includes(RIGHT_CLAIMREVIEW) ? (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed) : null,
+      this.columns.feedbackStatus !== "H" ? (c) => this.feedbackColFormatter(c) : null,
+      this.columns.reviewStatus !== "H" ? (c) => this.reviewColFormatter(c) : null,
+      (c) => formatAmount(this.props.modulesManager, this.props.intl, c.claimed),
+      (c) => formatAmount(this.props.modulesManager, this.props.intl, c.approved),
       (c) => formatMessage(this.props.intl, "claim", `claimStatus.${c.status}`),
     ];
     if (this.showPreAuthorization) {
@@ -289,7 +292,7 @@ class ClaimSearcher extends Component {
 
   rowHighlightedAlt = (selection, claim) =>
     !!this.highlightAltInsurees &&
-    selection.filter((c) => _.isEqual(c.insuree, claim.insuree)).length && 
+    selection.filter((c) => _.isEqual(c.insuree, claim.insuree)).length &&
     !selection.includes(claim);
 
   isRestoredClaim = (claim) => claim?.restoreId;
@@ -302,6 +305,7 @@ class ClaimSearcher extends Component {
 
   render() {
     const {
+      rights,
       intl,
       claims,
       claimsPageInfo,
@@ -321,7 +325,7 @@ class ClaimSearcher extends Component {
     if (!count) {
       count = (claimsPageInfo?.totalCount || 0).toLocaleString();
     }
-
+    console.log(intl);
     return (
       <Fragment>
         <PublishedComponent
@@ -373,6 +377,7 @@ class ClaimSearcher extends Component {
 }
 
 const mapStateToProps = (state) => ({
+  rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
   claims: state.claim.claims,
   claimsPageInfo: state.claim.claimsPageInfo,
   fetchingClaims: state.claim.fetchingClaims,

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -38,7 +38,7 @@ class ClaimSearcher extends Component {
       "claimFilter.rowsPerPageOptions",
       [10, 20, 50, 100],
     );
-    this.fields = props.modulesManager.getConf("fe-claim", "fields", {});
+    this.columns = props.modulesManager.getConf("fe-claim", "columns", {});
     this.defaultPageSize = props.modulesManager.getConf("fe-claim", "claimFilter.defaultPageSize", 10);
     this.highlightAmount = parseInt(props.modulesManager.getConf("fe-claim", "claimFilter.highlightAmount", 0));
     this.highlightAltInsurees = props.modulesManager.getConf("fe-claim", "claimFilter.highlightAltInsurees", true);
@@ -176,7 +176,7 @@ class ClaimSearcher extends Component {
       "claimSummaries.healthFacility",
       "claimSummaries.insuree",
       "claimSummaries.claimedDate",
-      this.fields?.processedDate !== "H" ? "claimSummaries.processedDate" : null,
+      this.columns?.processedDate !== "H" ? "claimSummaries.processedDate" : null,
       "claimSummaries.feedbackStatus",
       "claimSummaries.reviewStatus",
       "claimSummaries.claimed",
@@ -245,7 +245,7 @@ class ClaimSearcher extends Component {
       ),
       (c) => <PublishedComponent readOnly={true} pubRef="insuree.InsureePicker" withLabel={false} value={c.insuree} />,
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateClaimed),
-      (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed),
+      this.columns?.processedDate !== "H" ? (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed) : null,
       (c) => this.feedbackColFormatter(c),
       (c) => this.reviewColFormatter(c),
       (c) => formatAmount(this.props.intl, c.claimed),

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -38,6 +38,7 @@ class ClaimSearcher extends Component {
       "claimFilter.rowsPerPageOptions",
       [10, 20, 50, 100],
     );
+    this.fields = props.modulesManager.getConf("fe-claim", "fields", {});
     this.defaultPageSize = props.modulesManager.getConf("fe-claim", "claimFilter.defaultPageSize", 10);
     this.highlightAmount = parseInt(props.modulesManager.getConf("fe-claim", "claimFilter.highlightAmount", 0));
     this.highlightAltInsurees = props.modulesManager.getConf("fe-claim", "claimFilter.highlightAltInsurees", true);
@@ -175,7 +176,7 @@ class ClaimSearcher extends Component {
       "claimSummaries.healthFacility",
       "claimSummaries.insuree",
       "claimSummaries.claimedDate",
-      "claimSummaries.processedDate",
+      this.fields?.processedDate !== "H" ? "claimSummaries.processedDate" : null,
       "claimSummaries.feedbackStatus",
       "claimSummaries.reviewStatus",
       "claimSummaries.claimed",


### PR DESCRIPTION
#conditionally hide " processedDate" column in  ClaimSearcher also "processed from" and "processed to" fields in ClaimFilter using user right "RIGHT CLAIMREVIEW"  because this information is not so important for user that don't make claims review. In the screenshot below you can see the "processed-on" because the user is the super one.

#conditionally hide "pre-authorization" column in ClaimSearcher by db config "columns { }" for fe-claim modules...

<img width="1920" height="1080" alt="Capture d’écran du 2025-09-12 10-14-12" src="https://github.com/user-attachments/assets/c39c9e0c-1d3f-4f7a-b626-653f06f9ce37" />
