### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import moment from "moment";
-import { Fab, Badge } from "@material-ui/core";
+import { Fab, Badge, Button } from "@material-ui/core";
 import { withStyles, withTheme } from "@material-ui/core/styles";
 import CheckIcon from "@material-ui/icons/Check";
 import ReplayIcon from "@material-ui/icons/Replay";
@@ -500,7 +500,9 @@ class ClaimForm extends Component {
     if (!!claim_uuid && rights.includes(RIGHT_PRINT)) {
       actions.push({
         doIt: (e) => this.print(claim_uuid),
-        icon: <PrintIcon />,
+        icon: <Button startIcon={<PrintIcon />}>
+        {formatMessage(this.props.intl, "claim", "claim.print.buttonText")}
+        </Button>,
         onlyIfNotDirty: true,
       });
     }
@@ -508,9 +510,11 @@ class ClaimForm extends Component {
       actions.push({
         doIt: (e) => this.setState({ attachmentsClaim: claim }),
         icon: (
-          <Badge badgeContent={this.state.claim?.attachmentsCount ?? 0} color="primary">
-            <AttachIcon />
-          </Badge>
+          <Button 
+          startIcon={<Badge badgeContent={this.state.claim?.attachmentsCount ?? 0} color="primary">
+          <AttachIcon />
+          </Badge>}>
+          {formatMessage(this.props.intl, "claim", "claimAttachments.buttonText")}          </Button>
         ),
       });
     }
@@ -526,6 +530,7 @@ class ClaimForm extends Component {
           <span>
             <Fab color="primary" onClick={(e) => this.restore()}>
               <RestorePageIcon />
+              
             </Fab>
           </span>
         ),

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -273,10 +273,13 @@ class ClaimSearcher extends Component {
     }
     result.push((c) => (
       <Tooltip title={formatMessage(this.props.intl, "claim", "openNewTabButton.tooltip")}>
-        <IconButton onClick={(e) => this.props.onDoubleClick(c, true)}>
-          {" "}
-          <TabIcon />
-        </IconButton>
+        <div>
+          <IconButton onClick={(e) => this.props.onDoubleClick(c, true)}>
+            {" "}
+            <TabIcon />
+          </IconButton>
+          {formatMessage(this.props.intl, "claim", "openNewTab.buttonText")}
+        </div>
       </Tooltip>
     ));
     return result;

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import _ from "lodash";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { IconButton, Typography, Tooltip, Badge } from "@material-ui/core";
+import { Button, Typography, Tooltip, Badge } from "@material-ui/core";
 import AttachIcon from "@material-ui/icons/AttachFile";
 import TabIcon from "@material-ui/icons/Tab";
 import CheckIcon from "@material-ui/icons/Check";
@@ -258,11 +258,16 @@ class ClaimSearcher extends Component {
       result.push(
         (c) =>
           !!c.attachmentsCount && (
-            <IconButton onClick={(e) => this.setState({ attachmentsClaim: c })}>
-              <Badge badgeContent={c.attachmentsCount ?? 0} color="primary">
-                <AttachIcon />
-              </Badge>
-            </IconButton>
+            <Button
+              startIcon={
+                <Badge badgeContent={c.attachmentsCount ?? 0} color="primary">
+                  <AttachIcon />
+                </Badge>
+              }
+              onClick={(e) => this.setState({ attachmentsClaim: c })}
+            >
+              {formatMessage(this.props.intl, "claim", "claimAttachments.buttonText")}
+            </Button>
           ),
       );
     }
@@ -273,13 +278,9 @@ class ClaimSearcher extends Component {
     }
     result.push((c) => (
       <Tooltip title={formatMessage(this.props.intl, "claim", "openNewTabButton.tooltip")}>
-        <div>
-          <IconButton onClick={(e) => this.props.onDoubleClick(c, true)}>
-            {" "}
-            <TabIcon />
-          </IconButton>
+        <Button startIcon={<TabIcon />} onClick={(e) => this.props.onDoubleClick(c, true)}>
           {formatMessage(this.props.intl, "claim", "openNewTab.buttonText")}
-        </div>
+        </Button>
       </Tooltip>
     ));
     return result;

--- a/src/pages/ReviewsPage.js
+++ b/src/pages/ReviewsPage.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
-import { Grid, InputAdornment, IconButton, Tooltip } from "@material-ui/core";
+import { Grid, InputAdornment, IconButton, Tooltip, Button } from "@material-ui/core";
 import FilterIcon from "@material-ui/icons/FilterList";
 import FeedbackIcon from "@material-ui/icons/SpeakerNotesOutlined";
 import ReviewIcon from "@material-ui/icons/SupervisorAccount";
@@ -493,9 +493,10 @@ class ReviewsPage extends Component {
       {!!this.props.rights.includes(RIGHT_FEEDBACK) && (
         <Grid item>
           <Tooltip title={formatMessage(this.props.intl, "claim", "feedbackButton.tooltip")}>
-            <IconButton onClick={(e) => this.provideFeedback(c)}>
+            <Button onClick={(e) => this.provideFeedback(c)}>
               <FeedbackIcon />
-            </IconButton>
+              {formatMessage(this.props.intl, "claim", "claimFeedback.buttonText")}
+            </Button>
           </Tooltip>
         </Grid>
       )}
@@ -568,9 +569,10 @@ class ReviewsPage extends Component {
       {!!this.props.rights.includes(RIGHT_CLAIMREVIEW) && (
         <Grid item>
           <Tooltip title={formatMessage(this.props.intl, "claim", "reviewButton.tooltip")}>
-            <IconButton onClick={(e) => this.review(c)}>
+            <Button onClick={(e) => this.review(c)}>
               <ReviewIcon />
-            </IconButton>
+              {formatMessage(this.props.intl, "claim", "claimReview.buttonText")}
+            </Button>
           </Tooltip>
         </Grid>
       )}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -40,6 +40,7 @@
   "claim.feedbackButton.tooltip": "Deliver Feedback",
   "claim.reviewButton.tooltip": "Deliver Review",
   "claim.openNewTabButton.tooltip": "Open in new tab",
+  "claim.openNewTab.buttonText": "Open",
   "claim.ClaimFilter.claimedDateFrom": "Claimed From",
   "claim.ClaimFilter.claimedDateTo": "Claimed To",
   "claim.ClaimFilter.claimedAbove": "Claimed More Than",
@@ -370,5 +371,6 @@
   "claim.gql_mutation_process_claims_perms": "Claim | Mutation Process Claims",
   "claim.gql_mutation_restore_claims_perms": "Claim | Mutation Restore Claims",
   "claim.gql_mutation_delete_claims_perms": "Claim | Mutation Delete Claims",
-  "claim.claim_print_perms": "Claim | Claim Print"
+  "claim.claim_print_perms": "Claim | Claim Print",
+  "claim.deleteHealthFacility.textButton": "Delete"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,11 @@
 {
   "claim.mainMenu": "Claims",
+  "claimAttachments.buttonText": "Attachs",
+  "claim.print.buttonText": "Print",
+  "claim.restore.buttonText": "Restore",
+  "claim.duplicate.buttonText": "Duplicate",
+  "claim.claimFeedback.buttonText": "Feedback",
+  "claim.claimReview.buttonText": "Review",
   "claim.menu.healthFacilityClaims": "Health Facility Claims",
   "claim.healthFacilityClaims.page.title": "Health Facility Claims",
   "claim.menu.reviews": "Reviews",


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.

<img width="1854" height="935" alt="Capture d’écran du 2025-09-27 18-25-42" src="https://github.com/user-attachments/assets/7dabdfe9-f990-46aa-b097-f5314a60e748" />
<img width="1854" height="935" alt="Capture d’écran du 2025-09-27 18-25-53" src="https://github.com/user-attachments/assets/50504fed-fe94-4e59-97ef-93220567689d" />
<img width="1843" height="564" alt="Capture d’écran du 2025-09-27 18-26-30" src="https://github.com/user-attachments/assets/cb3d009b-e137-4b39-9889-005a4e3adc20" />
