### PR TITLE
improve ClaimSearcher UI

### DIFF
--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -234,8 +234,13 @@ class ClaimSearcher extends Component {
   itemFormatters = () => {
     var result = [
       (c) => c.code,
-      (c) => formatMessage(this.props.intl, "claim", `${c.healthFacility.code}`),
-      (c) => formatMessage(this.props.intl, "claim", `${c.insuree.lastName} ${c.insuree.otherNames}`),
+      (c) => c.healthFacility.code,
+      (c) => <TextField 
+                variant="standard"
+                InputProps={{
+                  disableUnderline: true,
+                  value: `${c.insuree.lastName} ${c.insuree.otherNames}`
+              }}/>,
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateClaimed),
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed),
       (c) => this.feedbackColFormatter(c),

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import _ from "lodash";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { IconButton, Typography, Tooltip, Badge } from "@material-ui/core";
+import { IconButton, Typography, Tooltip, Badge, TextField } from "@material-ui/core";
 import AttachIcon from "@material-ui/icons/AttachFile";
 import TabIcon from "@material-ui/icons/Tab";
 import CheckIcon from "@material-ui/icons/Check";
@@ -234,15 +234,8 @@ class ClaimSearcher extends Component {
   itemFormatters = () => {
     var result = [
       (c) => c.code,
-      (c) => (
-        <PublishedComponent
-          readOnly={true}
-          pubRef="location.HealthFacilityPicker"
-          withLabel={false}
-          value={c.healthFacility}
-        />
-      ),
-      (c) => <PublishedComponent readOnly={true} pubRef="insuree.InsureePicker" withLabel={false} value={c.insuree} />,
+      (c) => formatMessage(this.props.intl, "claim", `${c.healthFacility.code}`),
+      (c) => formatMessage(this.props.intl, "claim", `${c.insuree.lastName} ${c.insuree.otherNames}`),
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateClaimed),
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed),
       (c) => this.feedbackColFormatter(c),


### PR DESCRIPTION
replace picker in readonly mode by text and set the useful datas in ClaimSearcher columns as show in the screenshots below... 
before ======> after
<img width="1857" height="935" alt="Capture d’écran du 2025-10-01 16-48-59" src="https://github.com/user-attachments/assets/220401e6-089b-4af1-914f-29b7c5199965" />
 
<img width="1857" height="935" alt="Capture d’écran du 2025-10-01 16-46-08" src="https://github.com/user-attachments/assets/8610c76a-75a9-4a61-8794-8b1f2eb1a123" />
