### PR TITLE
set a tooltip on item or service pickers

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -346,24 +346,27 @@ class ClaimChildPanel extends Component {
 
     let itemFormatters = [
       (i, idx) => (
-        <Tooltip 
-        title={formatMessage(intl, "claim", "ClaimChildPanel.itemOrService.tooltip")}
-        sx={{ fontSize: '3rem'}}
+        <Tooltip
+          title={formatMessage(intl, "claim", "ClaimChildPanel.itemOrService.tooltip")}
+          disableHoverListener={!!forReview || !!readOnly}
+          disableFocusListener={!!forReview || !!readOnly}
+          sx={{ fontSize: '3rem' }}
         >
-        <Box minWidth={400}>
-          <PublishedComponent
-            readOnly={!!forReview || readOnly}
-            pubRef={picker}
-            filterOptions={this.props.type==='item' ? filterItemsOptions : filterServicesOptions}
-            withLabel={false}
-            value={i[type]}
-            fullWidth
-            pricelistUuid={edited.healthFacility[`${this.props.type}sPricelist`].uuid}
-            date={edited.dateClaimed}
-            onChange={(v) => this._onChangeItem(idx, type, v)}
-          />
-        </Box>
+          <Box minWidth={400}>
+            <PublishedComponent
+              readOnly={!!forReview || readOnly}
+              pubRef={picker}
+              filterOptions={this.props.type === 'item' ? filterItemsOptions : filterServicesOptions}
+              withLabel={false}
+              value={i[type]}
+              fullWidth
+              pricelistUuid={edited.healthFacility[`${this.props.type}sPricelist`].uuid}
+              date={edited.dateClaimed}
+              onChange={(v) => this._onChangeItem(idx, type, v)}
+            />
+          </Box>
         </Tooltip>
+
       ),
       (i, idx) => (
         <NumberInput

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -347,7 +347,7 @@ class ClaimChildPanel extends Component {
     let itemFormatters = [
       (i, idx) => (
         <Tooltip 
-        title={"Type if you dont find the item or service in the list"}
+        title={formatMessage(intl, "claim", "ClaimChildPanel.itemOrService.tooltip")}
         sx={{ fontSize: '3rem'}}
         >
         <Box minWidth={400}>

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import _ from "lodash";
 
-import { Paper, Box, IconButton, Typography, Grid, TableCell } from "@material-ui/core";
+import { Paper, Box, IconButton, Typography, Grid, TableCell, Tooltip } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { ThumbUp, ThumbDown } from "@material-ui/icons";
 
@@ -346,6 +346,10 @@ class ClaimChildPanel extends Component {
 
     let itemFormatters = [
       (i, idx) => (
+        <Tooltip 
+        title={"Type if you dont find the item or service in the list"}
+        sx={{ fontSize: '3rem'}}
+        >
         <Box minWidth={400}>
           <PublishedComponent
             readOnly={!!forReview || readOnly}
@@ -359,6 +363,7 @@ class ClaimChildPanel extends Component {
             onChange={(v) => this._onChangeItem(idx, type, v)}
           />
         </Box>
+        </Tooltip>
       ),
       (i, idx) => (
         <NumberInput

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,6 @@
 {
   "claim.mainMenu": "Claims",
+  "ClaimChildPanel.itemOrService.tooltip": "Type if you dont find the item or service in the list",
   "claim.menu.healthFacilityClaims": "Health Facility Claims",
   "claim.healthFacilityClaims.page.title": "Health Facility Claims",
   "claim.menu.reviews": "Reviews",


### PR DESCRIPTION
In the claim creation interface, when adding a service, it is not intuitive for the user to understand that they can type in the field to search for a service that is not directly displayed in the picker’s suggestions. To improve the user experience, we added a tooltip message to give this indication to the user. 

<img width="1009" height="394" alt="Capture d’écran du 2025-10-01 17-03-35" src="https://github.com/user-attachments/assets/3085d196-126e-4b5c-8bdf-91719849ff70" />
