### PR TITLE
set an asterix on item/service fields in claim form

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -343,12 +343,12 @@ class ClaimChildPanel extends Component {
       let currentServicesIds = edited.services ? edited.services.map((claimService) => claimService?.service?.id) : [];
       return options.filter((option) => !currentServicesIds.includes(option.id));
     }
-
+console.log("edited", this.props.edited)
     let itemFormatters = [
       (i, idx) => (
         <Box minWidth={400}>
           <PublishedComponent
-            required={true}
+            required={(!!edited.services && edited.services?.length<2 && !!edited.items && edited?.items?.length<2) || (!edited.services && !edited.items)}
             readOnly={!!forReview || readOnly}
             pubRef={picker}
             filterOptions={this.props.type==='item' ? filterItemsOptions : filterServicesOptions}

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -344,7 +344,7 @@ class ClaimChildPanel extends Component {
       let currentServicesIds = edited.services ? edited.services.map((claimService) => claimService?.service?.id) : [];
       return options.filter((option) => !currentServicesIds.includes(option.id));
     }
-console.log("edited", this.props.edited)
+
     let itemFormatters = [
       (i, idx) => (
         <Tooltip
@@ -358,7 +358,7 @@ console.log("edited", this.props.edited)
               required={(!!edited.services && edited.services?.length<2 && !!edited.items && edited?.items?.length<2) || (!edited.services && !edited.items)}
               readOnly={!!forReview || readOnly}
               pubRef={picker}
-              filterOptions={this.props.type==='item' ? filterItemsOptions : filterServicesOptions}
+              filterOptions={this.props.type === 'item' ? filterItemsOptions : filterServicesOptions}
               withLabel={false}
               value={i[type]}
               fullWidth

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -348,12 +348,11 @@ class ClaimChildPanel extends Component {
       (i, idx) => (
         <Box minWidth={400}>
           <PublishedComponent
+            required={true}
             readOnly={!!forReview || readOnly}
             pubRef={picker}
             filterOptions={this.props.type==='item' ? filterItemsOptions : filterServicesOptions}
-            withLabel={false}
             value={i[type]}
-            fullWidth
             pricelistUuid={edited.healthFacility[`${this.props.type}sPricelist`].uuid}
             date={edited.dateClaimed}
             onChange={(v) => this._onChangeItem(idx, type, v)}


### PR DESCRIPTION
we added an asterix in item/service pickers fields in their respective panels located in claim form page to make the user know that he has to fill this at least one of these to enable the save button.

<img width="1826" height="624" alt="Capture d’écran du 2025-10-03 10-58-47" src="https://github.com/user-attachments/assets/7ced60f6-e2cc-4f92-ab50-9cc61e9df453" />
