### PR TITLE
fix items/services form for rejected claims OP-2760

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -72,7 +72,7 @@ class ClaimChildPanel extends Component {
       data.forEach((d) => !!d.services && (d.subServices = d.services));
       data.forEach((d) => !!d.items && (d.subItems = d.items));
     }
-    if (!this.props.forReview && this.props.edited.status == 2 && !_.isEqual(data[data.length - 1], {})) {
+    if (!this.props.forReview && (this.props.edited.status === 1 || this.props.edited.status === 2) && !_.isEqual(data[data.length - 1], {})) {
       data.push({});
     }
     return data;

--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -72,7 +72,7 @@ class ClaimChildPanel extends Component {
       data.forEach((d) => !!d.services && (d.subServices = d.services));
       data.forEach((d) => !!d.items && (d.subItems = d.items));
     }
-    if (!this.props.forReview && (this.props.edited.status === 1 || this.props.edited.status === 2) && !_.isEqual(data[data.length - 1], {})) {
+    if (!this.props.forReview && this.props.edited.status === 2 && !_.isEqual(data[data.length - 1], {})) {
       data.push({});
     }
     return data;
@@ -91,8 +91,8 @@ class ClaimChildPanel extends Component {
       this.setState({ data, reset: this.state.reset + 1 });
     } else if (
       prevProps.reset !== this.props.reset ||
-      (!!this.props.edited[`${this.props.type}s`] &&
-        !_.isEqual(prevProps.edited[`${this.props.type}s`], this.props.edited[`${this.props.type}s`]))
+      (!!this.props.edited &&
+        !_.isEqual(prevProps.edited, this.props.edited))
     ) {
       this.setState({
         data: this.initData(),

--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -299,20 +299,10 @@ class ClaimForm extends Component {
       return false
     } 
     if (this.state.claim.services !== undefined) {
-      if (this.props.forReview || this.state.isRestored) {
-        if (this.state.claim.services.length && this.state.claim.services.filter((s) => !this.canSaveDetail(s, "service")).length) {
-          return false;
-        }
-      } else {
-        if (this.state.claim.services.length && this.state.claim.services.filter((s) => !this.canSaveDetail(s, "service")).length - 1) {
-          return false;
-        }
+      if (this.state.claim.services.length && this.state.claim.services.filter((s) => !this.canSaveDetail(s, "service", forReview)).length - 1) {
+        return false;
       }
-
-    } else {
-      return false;
     }
-
 
     if (this.isCareTypeMandatory){
       if (!CARE_TYPE_STATUS.includes(this.state.claim.careType)) return false;


### PR DESCRIPTION
In native openimis, if there are no elements in the items/services panels of a rejected claim, the header of the panel concerned appears but not the body; this does not give the possibility to add an item/service when restoring the claim in question. We have fixed this

<img width="1852" height="988" alt="Capture d’écran du 2025-10-24 00-13-25" src="https://github.com/user-attachments/assets/6ff69579-ce34-4e8e-82e5-7703f332b983" />
<img width="1852" height="988" alt="Capture d’écran du 2025-10-24 00-15-00" src="https://github.com/user-attachments/assets/d596f8fe-df6b-4358-999b-dc5beaed7e78" />
