### PR TITLE
fix claimCode check for restored claims OP-2761

### DIFF
--- a/src/components/ClaimForm.js
+++ b/src/components/ClaimForm.js
@@ -166,6 +166,7 @@ class ClaimForm extends Component {
       ...claim,
       uuid: null,
       status: status,
+      code: "",
       restore: { uuid: claim.uuid, code: claim.code },
       items: items,
       services: services,

--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -95,8 +95,9 @@ class ClaimMasterPanel extends FormPanel {
   shouldValidate = (inputValue) => {
     if (this.autoGenerateClaimCode) return false;
 
-    const { savedClaimCode } = this.props;
+    const { savedClaimCode, edited } = this.props;
     const shouldValidate = inputValue !== savedClaimCode;
+    if (edited.restore) return true;
     return shouldValidate;
   };
 

--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -96,8 +96,10 @@ class ClaimMasterPanel extends FormPanel {
     if (this.autoGenerateClaimCode) return false;
 
     const { savedClaimCode, edited } = this.props;
-    const shouldValidate = inputValue !== savedClaimCode;
+
     if (edited.restore) return true;
+    const shouldValidate = inputValue !== savedClaimCode;
+
     return shouldValidate;
   };
 


### PR DESCRIPTION
In Openimis, when a rejected claim is restored, it is possible to submit it with the original claim code. The uniqueness check was not working in this case, we fixed this.

<img width="1840" height="984" alt="Capture d’écran du 2025-10-24 15-52-46" src="https://github.com/user-attachments/assets/0c13b92c-7f35-4c7c-beda-bd6e8407b5f8" />
<img width="1840" height="984" alt="Capture d’écran du 2025-10-24 16-03-41" src="https://github.com/user-attachments/assets/57f4d9b8-2efc-48af-a86f-acee31cee6ed" />
