### PR TITLE
set automatically claimAdmin OP-2798

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -21,6 +21,12 @@ export function selectClaimAdmin(admin) {
   };
 }
 
+export function setCurrentClaimAdmin(admin) {
+  return (dispatch) => {
+    dispatch({ type: "CLAIM_SET_CURRENT_CLAIM_ADMIN", payload: admin });
+  };
+}
+
 export function selectHealthFacility(hf) {
   return (dispatch) => {
     dispatch({ type: "CLAIM_CLAIM_HEALTH_FACILITY_SELECTED", payload: hf });

--- a/src/pages/HealthFacilitiesPage.js
+++ b/src/pages/HealthFacilitiesPage.js
@@ -18,7 +18,7 @@ import {
   clearCurrentPaginationPage,
 } from "@openimis/fe-core";
 import ClaimSearcher from "../components/ClaimSearcher";
-import { submit, del, selectHealthFacility, submitAll } from "../actions";
+import { submit, del, selectHealthFacility, submitAll, selectClaimAdmin } from "../actions";
 import { RIGHT_ADD, RIGHT_LOAD, RIGHT_SUBMIT, RIGHT_DELETE, MODULE_NAME } from "../constants";
 
 const CLAIM_HF_FILTER_CONTRIBUTION_KEY = "claim.HealthFacilitiesFilter";
@@ -130,12 +130,14 @@ class HealthFacilitiesPage extends Component {
   };
 
   onAdd = () => {
+    this.props.selectClaimAdmin(this.props.currentClaimAdmin);
+    this.props.selectHealthFacility(this.props.currentUserHF);
     historyPush(this.props.modulesManager, this.props.history, "claim.route.claimEdit");
   };
 
   canAdd = () => {
-    if (!this.props.claimAdmin) return false;
-    if (!this.props.claimHealthFacility) return false;
+    // if (!this.props.claimAdmin) return false;
+    // if (!this.props.claimHealthFacility) return false;
     return true;
   };
 
@@ -205,6 +207,9 @@ class HealthFacilitiesPage extends Component {
 }
 
 const mapStateToProps = (state) => ({
+  state,
+  currentClaimAdmin: state.claim.currentClaimAdmin,
+  currentUserHF: state.loc?.userHealthFacilityFullPath,
   rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
   claimAdmin: state.claim.claimAdmin,
   claimHealthFacility: state.claim.claimHealthFacility,
@@ -221,6 +226,7 @@ const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
     {
       selectHealthFacility,
+      selectClaimAdmin,
       journalize,
       coreConfirm,
       submit,

--- a/src/pages/HealthFacilitiesPage.js
+++ b/src/pages/HealthFacilitiesPage.js
@@ -136,8 +136,6 @@ class HealthFacilitiesPage extends Component {
   };
 
   canAdd = () => {
-    // if (!this.props.claimAdmin) return false;
-    // if (!this.props.claimHealthFacility) return false;
     return true;
   };
 

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -91,11 +91,12 @@ const ClaimAdminPicker = (props) => {
   };
   const claimAdmins = data?.claimAdmins?.edges.map((edge) => edge.node) || [];
 
-  for (const admin of claimAdmins) {
-    if (admin.code === i_user) {
-      dispatch(setCurrentClaimAdmin(admin));
+  useEffect(() => {
+    const currentAdmin = claimAdmins.find((admin) => admin.code === i_user);
+    if (currentAdmin) {
+      dispatch(setCurrentClaimAdmin(currentAdmin));
     }
-  }
+  }, [claimAdmins, i_user]);
 
   return (
     <Autocomplete

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 
 import {
   useModulesManager,
@@ -8,6 +8,7 @@ import {
   useGraphqlQuery,
 } from "@openimis/fe-core";
 import { DEFAULT } from "../constants";
+import { setCurrentClaimAdmin } from "../actions";
 
 
 const ClaimAdminPicker = (props) => {
@@ -30,6 +31,9 @@ const ClaimAdminPicker = (props) => {
   } = props;
   const userHealthFacilityId = useSelector((state) =>
     state?.loc?.userHealthFacilityFullPath?.uuid
+  );
+  const i_user = useSelector((state) =>
+    state?.core?.user?.username
   );
 
   const modulesManager = useModulesManager();
@@ -79,11 +83,19 @@ const ClaimAdminPicker = (props) => {
     },
   );
 
+  const dispatch = useDispatch();
   const formatClaimAdmin = (claimAdmin) => {
     return renderLastNameFirst
       ? `${claimAdmin.code} ${claimAdmin.lastName} ${claimAdmin.otherNames}`
       : `${claimAdmin.code} ${claimAdmin.otherNames} ${claimAdmin.lastName}`;
   };
+  const claimAdmins = data?.claimAdmins?.edges.map((edge) => edge.node) || [];
+
+  for (let i = 0; i < claimAdmins.length; i++) {
+    if (claimAdmins[i].code === i_user) {
+      dispatch(setCurrentClaimAdmin(claimAdmins[i]));
+    }
+  }
 
   return (
     <Autocomplete
@@ -95,7 +107,7 @@ const ClaimAdminPicker = (props) => {
       withLabel={withLabel}
       withPlaceholder={withPlaceholder}
       readOnly={readOnly}
-      options={data?.claimAdmins?.edges.map((edge) => edge.node) ?? []}
+      options={claimAdmins}
       isLoading={isLoading}
       value={value}
       getOptionLabel={(option) => formatClaimAdmin(option)}

--- a/src/pickers/ClaimAdminPicker.js
+++ b/src/pickers/ClaimAdminPicker.js
@@ -91,9 +91,9 @@ const ClaimAdminPicker = (props) => {
   };
   const claimAdmins = data?.claimAdmins?.edges.map((edge) => edge.node) || [];
 
-  for (let i = 0; i < claimAdmins.length; i++) {
-    if (claimAdmins[i].code === i_user) {
-      dispatch(setCurrentClaimAdmin(claimAdmins[i]));
+  for (const admin of claimAdmins) {
+    if (admin.code === i_user) {
+      dispatch(setCurrentClaimAdmin(admin));
     }
   }
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,6 +10,7 @@ import {
 
 function reducer(
   state = {
+    currentClaimAdmin: null,
     fetchingClaimAttachments: false,
     fetchedClaimAttachments: false,
     errorClaimAttachments: null,
@@ -86,6 +87,10 @@ function reducer(
         s.claimDistrict = s.claimHealthFacility.location;
         s.claimRegion = s.claimDistrict.parent;
       }
+      return s;
+    case "CLAIM_SET_CURRENT_CLAIM_ADMIN":
+      var currentClaimAdmin = action.payload;
+      var s = { ...state, currentClaimAdmin };
       return s;
     case "CLAIM_CLAIM_HEALTH_FACILITY_SELECTED":
       var claimHealthFacility = action.payload;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -89,8 +89,8 @@ function reducer(
       }
       return s;
     case "CLAIM_SET_CURRENT_CLAIM_ADMIN":
-      var currentClaimAdmin = action.payload;
-      var s = { ...state, currentClaimAdmin };
+      const currentClaimAdmin = action.payload;
+      s = { ...state, currentClaimAdmin };
       return s;
     case "CLAIM_CLAIM_HEALTH_FACILITY_SELECTED":
       var claimHealthFacility = action.payload;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -88,10 +88,11 @@ function reducer(
         s.claimRegion = s.claimDistrict.parent;
       }
       return s;
-    case "CLAIM_SET_CURRENT_CLAIM_ADMIN":
+    case "CLAIM_SET_CURRENT_CLAIM_ADMIN": {
       const currentClaimAdmin = action.payload;
       s = { ...state, currentClaimAdmin };
       return s;
+    }
     case "CLAIM_CLAIM_HEALTH_FACILITY_SELECTED":
       var claimHealthFacility = action.payload;
       var s = { ...state, claimHealthFacility };


### PR DESCRIPTION
When creating a new claim, the claim admin is now automatically set to the currently logged-in user.