### PR TITLE
Add program management in claim

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -293,6 +293,7 @@ export function formatClaimGQL(modulesManager, claim, shouldAutogenerate) {
     preAuthorization: ${claim.preAuthorization}
     ${!!claim.patientCondition ? `patientCondition: "${formatGQLString(claim.patientCondition)}"` : ""}
     ${!!claim.referralCode ? `referralCode: "${formatGQLString(claim.referralCode)}"` : ""}
+    ${!!claim.program ? `program: ${decodeId(claim.program.id)}` : ""}
  `;
 }
 
@@ -358,6 +359,7 @@ export function fetchClaim(mm, claimUuid, forFeedback) {
     "patientCondition",
     "referralCode",
     "jsonExt",
+    "program {id code idProgram nameProgram validityDateFrom}"
   ];
   if (!!forFeedback) {
     projections.push(

--- a/src/components/ClaimChildPanel.jsx
+++ b/src/components/ClaimChildPanel.jsx
@@ -307,7 +307,7 @@ class ClaimChildPanel extends Component {
   };
 
   render() {
-    const { intl, edited, type, picker, forReview, fetchingPricelist, readOnly = false, modulesManager } = this.props;
+    const { intl, classes, edited, type, picker, forReview, fetchingPricelist, readOnly = false, modulesManager } = this.props;
     if (!edited) return null;
     if (!this.props.edited.healthFacility || !this.props.edited.healthFacility[`${this.props.type}sPricelist`]?.id) {
       return (

--- a/src/components/ClaimMasterPanel.jsx
+++ b/src/components/ClaimMasterPanel.jsx
@@ -91,6 +91,7 @@ class ClaimMasterPanel extends FormPanel {
       "claimForm.ComplexProductWithoutPriceImpact",
       true,
     );
+    this.isProgramAvailable = props.modulesManager.getConf("fe-core", "isProgramAvailable", false);
   }
 
   shouldValidate = (inputValue) => {
@@ -393,6 +394,25 @@ class ClaimMasterPanel extends FormPanel {
             </StyledItemGrid>
           }
         />
+        { this.isProgramAvailable && (
+          <ControlledField
+          module="claim"
+          id="Claim.program"
+          field={
+            <Grid item xs={3} className={classes.item}>
+              <PublishedComponent
+                pubRef="claim.ClaimProgramPicker"
+                name="program"
+                label={formatMessage(intl, "claim", "programPicker.label")}
+                value={edited.program}
+                reset={reset}
+                readOnly={!!edited && edited[`uuid`] ? true : ro}
+                onChange={(v) => this.updateAttribute("program", v)}
+              />
+            </Grid>
+          }
+        />
+        )}
         {this.fields.guaranteeNo !== "N" && (
           <ControlledField
             module="claim"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -28,6 +28,7 @@ import ClaimsPrimaryOperationalIndicators from "./reports/ClaimsPrimaryOperation
 import ClaimInsureeSummary from "./components/ClaimInsureeSummary";
 import YesNoPicker from "./pickers/YesNoPicker";
 import PatientConditionPicker from "./pickers/PatientConditionPicker";
+import ClaimProgramPicker from "./pickers/ClaimProgramPicker";
 import { RIGHT_ADD, RIGHT_SUBMIT, RIGHT_CLAIMREVIEW, RIGHT_PROCESS, RIGHT_FEEDBACK, RIGHT_SEARCH, RIGHT_HF_SEARCH } from "./constants";
 
 const Keyboard = GetIconComponent("Keyboard")
@@ -181,6 +182,7 @@ const DEFAULT_CONFIG = {
     { key: "claim.AttachmentsDialog", ref: AttachmentsDialog },
     { key: "claim.YesNoPicker", ref: YesNoPicker },
     { key: "claim.PatientConditionPicker", ref: PatientConditionPicker },
+    { key: "claim.ClaimProgramPicker", ref: ClaimProgramPicker},
   ],
   "core.Router": [
     { path: ROUTE_HEALTH_FACILITIES, text: "claim.menu.healthFacilityClaims",id: "claim.healthFacilityClaims", component: HealthFacilitiesPage, rights:[RIGHT_SEARCH, RIGHT_HF_SEARCH], icon: "Keyboard" },

--- a/src/pickers/ClaimProgramPicker.js
+++ b/src/pickers/ClaimProgramPicker.js
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import { useModulesManager, useTranslations, Autocomplete, useGraphqlQuery } from "@openimis/fe-core";
+import _debounce from "lodash/debounce";
+
+const ClaimProgramPicker = (props) => {
+  const {
+    onChange,
+    readOnly,
+    required,
+    withLabel = true,
+    withPlaceholder,
+    value,
+    label,
+    filterOptions,
+    filterSelectedOptions,
+    placeholder,
+    multiple,
+    extraFragment,
+  } = props;
+
+  const modulesManager = useModulesManager();
+  const { formatMessage } = useTranslations("claim", modulesManager);
+  const [searchString, setSearchString] = useState("");
+  const { isLoading, data, error } = useGraphqlQuery(
+    `
+      query ProgramPicker {
+          program(first: 20) {
+              edges {
+                  node {
+                      id
+                      idProgram
+                      code
+                      nameProgram
+                      validityDateFrom
+                      ${extraFragment ?? ""}
+                    }
+                }
+            }
+        }
+        `,
+        null,
+  );
+
+  return (
+    <Autocomplete
+      multiple={multiple}
+      required={required}
+      placeholder={placeholder ?? formatMessage("program.programPicker.placeholder")}
+      label={label ?? formatMessage("program.label")}
+      error={error}
+      withLabel={withLabel}
+      withPlaceholder={withPlaceholder}
+      readOnly={readOnly}
+      options={data?.program?.edges.map((edge) => edge.node) ?? []}
+      isLoading={isLoading}
+      value={value}
+      getOptionLabel={(option) => `${option.nameProgram}`}
+      onChange={(option) => onChange(option, option ? `${option.nameProgram}` : null)}
+      filterOptions={filterOptions}
+      filterSelectedOptions={filterSelectedOptions}
+      onInputChange={setSearchString}
+    />
+  );
+};
+
+export default ClaimProgramPicker;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -395,14 +395,6 @@
   "claim.attachment.definePredefinedType": "You must define the the General Type first and then select the Predefined Type or clean the attachment",
   "claim.attachment.missingDocument": "Missing Document",
   "claim.attachment.defineDocument": "Upload a file or clean the attachment",
-  "claim.ClaimHistoryModal.title": "History of Claim {code}",
-  "claimHistory.code": "Code",
-  "claimHistory.dateClaimed": "Date Claimed",
-  "claimHistory.dateProcessed": "Date Processed",
-  "claimHistory.feedbackStatus": "Feedback Status",
-  "claimHistory.reviewStatus": "Review Status",
-  "claimHistory.claimed": "Claimed",
-  "claimHistory.approved": "Approved",
-  "claimHistory.status": "Status",
-  "claimHistory.restoreId": "Restore ID"
+  "claim.programPicker.label": "Claim Program",
+  "claim.programPicker.placeholder": "program"
 }


### PR DESCRIPTION
# Description

This is a Cameroun program management for claim. We add field in form and others graphql requests. This field is only available when the global config isProgramAvaible has true value

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify


## Demo

<img width="1359" height="580" alt="Screenshot 2026-02-06 at 2 42 34 PM" src="https://github.com/user-attachments/assets/e20f998b-8e31-4cc5-ad1b-a27fefa3f5e9" />

## Checklist
- [ ] Unit tests added/modified
- [x] I18n / translation handled
