### PR TITLE
fix: formatAmount

### DIFF
--- a/src/components/ClaimChildPanel.js
+++ b/src/components/ClaimChildPanel.js
@@ -262,14 +262,14 @@ class ClaimChildPanel extends Component {
         {totalClaimed > 0 && (
           <Typography>
             {formatMessageWithValues(intl, "claim", `edit.${type}s.totalClaimed`, {
-              totalClaimed: formatAmount(intl, totalClaimed),
+              totalClaimed: formatAmount(this.props.modulesManager, intl, totalClaimed),
             })}
           </Typography>
         )}
         {totalClaimed > 0 && (
           <Typography>
             {formatMessageWithValues(intl, "claim", `edit.${type}s.totalApproved`, {
-              totalApproved: formatAmount(intl, totalApproved),
+              totalApproved: formatAmount(this.props.modulesManager, intl, totalApproved),
             })}
           </Typography>
         )}
@@ -318,7 +318,7 @@ class ClaimChildPanel extends Component {
     let preHeaders = [
       totalClaimed > 0
         ? formatMessageWithValues(intl, "claim", `edit.${type}s.totalClaimed`, {
-          totalClaimed: formatAmount(intl, totalClaimed),
+          totalClaimed: formatAmount(this.props.modulesManager, intl, totalClaimed),
         })
         : "",
     ];

--- a/src/components/ClaimInsureeSummary.js
+++ b/src/components/ClaimInsureeSummary.js
@@ -51,8 +51,8 @@ const ClaimInsureeSummary = ({ insuree }) => {
     (claim) => formatDateFromISO(claim?.dateProcessed),
     (claim) => formatMessage(`feedbackStatus.${claim?.feedbackStatus}`),
     (claim) => formatMessage(`reviewStatus.${claim?.reviewStatus}`),
-    (claim) => formatAmount(intl, claim?.claimed),
-    (claim) => formatAmount(intl, claim?.approved),
+    (claim) => formatAmount(modulesManager, intl, claim?.claimed),
+    (claim) => formatAmount(modulesManager, intl, claim?.approved),
     (claim) => formatMessage(`claimStatus.${claim?.status}`),
     (claim) => (
       <Tooltip title={formatMessage("ClaimMasterPanelExt.InsureeInfo.goToClaim.Button")}>

--- a/src/components/ClaimSearcher.js
+++ b/src/components/ClaimSearcher.js
@@ -156,6 +156,7 @@ class ClaimSearcher extends Component {
                 claimed: (
                   <b>
                     {formatAmount(
+                      this.props.modulesManager,
                       this.props.intl,
                       selection.reduce((acc, v) => {
                         if (v.claimed) {
@@ -178,6 +179,7 @@ class ClaimSearcher extends Component {
                 approved: (
                   <b>
                     {formatAmount(
+                      this.props.modulesManager,
                       this.props.intl,
                       selection.reduce((acc, v) => {
                         if (v.approved) {
@@ -186,7 +188,7 @@ class ClaimSearcher extends Component {
                           return acc;
                         }
                       }, 0),
-                    )}
+                    )}                    
                   </b>
                 ),
               }}
@@ -281,9 +283,9 @@ class ClaimSearcher extends Component {
       (c) => formatDateFromISO(this.props.modulesManager, this.props.intl, c.dateProcessed),
       (c) => this.feedbackColFormatter(c),
       (c) => this.reviewColFormatter(c),
-      (c) => formatAmount(this.props.intl, c.claimed),
-      (c) => formatAmount(this.props.intl, c.approved),
-      (c) => formatMessage(this.props.intl, "claim", `claimStatus.${c.status}`),
+      (c) => formatAmount(this.props.modulesManager, this.props.intl, c.claimed),
+      (c) => formatAmount(this.props.modulesManager, this.props.intl, c.approved),
+      (c) => formatMessage(this.props.intl, "claim", `claimStatus.${c.status}`),      
     ];
     if (this.showPreAuthorization) {
       result.push((c) => (c.preAuthorization ? <CheckIcon /> : ""));


### PR DESCRIPTION
# Description

this PR fix the formatAmount function in fe-claim to align it with the fe-core updates

SQL query to insert config in DB demo : 

UPDATE public."core_ModuleConfiguration"
SET config = '{"thousandSeparator": "en", "pricesAreDecimal": true, "numberOfDecimals": 2}'
WHERE id = '02a59ebe-61b6-445d-aa6b-d60d85f46111';

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
