### PR TITLE
fix(claim): guard history fetch, return feedback promise, and handle restored claim code validation OP-2514

### DIFF
--- a/src/components/ClaimHistoryPanel.js
+++ b/src/components/ClaimHistoryPanel.js
@@ -74,8 +74,8 @@ const ClaimHistoryPanel = ({ claim, claimUuid, onViewVersion, classes }) => {
   const [expanded, setExpanded] = React.useState(false);
 
   useEffect(() => {
-    dispatch(fetchClaimHistory(claimUuid));
-  }, [claimUuid, dispatch]);
+    if (!!claimUuid) dispatch(fetchClaimHistory(claimUuid));
+  }, [claimUuid]);
 
   const handleChange = (event, isExpanded) => {
     setExpanded(isExpanded);

--- a/src/components/ClaimMasterPanel.js
+++ b/src/components/ClaimMasterPanel.js
@@ -96,10 +96,9 @@ class ClaimMasterPanel extends FormPanel {
     if (this.autoGenerateClaimCode) return false;
 
     const { savedClaimCode, edited } = this.props;
+    if (edited.restore && !edited?.uuid) return true;
 
-    if (edited.restore) return true;
     const shouldValidate = inputValue !== savedClaimCode;
-
     return shouldValidate;
   };
 

--- a/src/pages/FeedbackPage.js
+++ b/src/pages/FeedbackPage.js
@@ -21,11 +21,12 @@ class FeedbackPage extends Component {
 
   save = (claim) => {
     if (!!claim && !!claim.feedback) {
-      this.props.deliverFeedback(
+      return this.props.deliverFeedback(
         claim,
         formatMessageWithValues(this.props.intl, "claim", "DeliverClaimFeedback.mutationLabel", { code: claim.code }),
       );
     }
+    return Promise.resolve();
   };
 
   render() {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -411,14 +411,14 @@ function reducer(
         ...state,
         fetchingHistory: false,
         fetchedHistory: true,
-        history: parseData(action.payload.data.claimHistory),
-        pageInfo: pageInfo(action.payload.data.claimHistory.pageInfo),
+        history: parseData(action.payload.data?.claimHistory),
+        pageInfo: pageInfo(action.payload.data?.claimHistory?.pageInfo),
       };
     case "CLAIM_HISTORY_FETCH_ERR":
       return {
         ...state,
         fetchingHistory: false,
-        errorHistory: formatGraphQLError(action.payload.data.errors),
+        errorHistory: formatGraphQLError(action.payload?.response?.errors),
       };
     default:
       return state;


### PR DESCRIPTION
# Description

This PR improves claim UI reliability around history loading, feedback submission, and restored claims.

Prevents unnecessary claim history fetches when claimUuid is missing.
Makes feedback save return the deliverFeedback promise (or a resolved promise when no feedback), ensuring consistent async behavior.
Fixes claim code validation logic for restored claims.
Adds null-safe handling in the reducer for claim history success/error payloads to avoid runtime issues with partial GraphQL responses.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
