### PR TITLE
fix: resolve ESM syntax errors breaking Vite bundling

### DIFF
--- a/src/components/ClaimFilter.jsx
+++ b/src/components/ClaimFilter.jsx
@@ -23,7 +23,6 @@ import {
   Contributions,
 } from "@openimis/fe-core";
 import { selectClaimAdmin, selectHealthFacility, selectDistrict, selectRegion } from "../actions";
-import { RIGHT_CLAIMREVIEW } from "../constants";
 
 const CLAIM_FILTER_CONTRIBUTION_KEY = "claim.Filter";
 

--- a/src/components/ClaimForm.jsx
+++ b/src/components/ClaimForm.jsx
@@ -44,7 +44,6 @@ import {
 import ClaimMasterPanel from "./ClaimMasterPanel";
 import ClaimChildPanel from "./ClaimChildPanel";
 import ClaimFeedbackPanel from "./ClaimFeedbackPanel";
-import ClaimHistoryPanel from "./ClaimHistoryPanel";
 const CheckIcon = GetIconComponent("Check")
 
 const ReplayIcon = GetIconComponent("Replay")
@@ -611,7 +610,8 @@ class ClaimForm extends Component {
               additionalTooltips={tooltips}
               {...editingProps}
             />
-        </StyledDiv>
+          </Fragment>
+        )}
       </StyledDiv>
       <StyledDiv>
         <ClaimHistoryPanel

--- a/src/components/ClaimInsureeSummary.jsx
+++ b/src/components/ClaimInsureeSummary.jsx
@@ -4,14 +4,11 @@ import { useIntl } from "react-intl";
 
 import { Typography, Grid, Paper, IconButton, Tooltip } from "@mui/material";
 import { useTheme, styled } from "@mui/material/styles";
-import { GetIconComponent } from "@openimis/fe-core";
-
-const VisibilityIcon = GetIconComponent("Visibility")
-
-
-import { useModulesManager, useTranslations, Table, useHistory, historyPush, formatAmount } from "@openimis/fe-core";
+import { GetIconComponent, useModulesManager, useTranslations, Table, useHistory, historyPush, formatAmount } from "@openimis/fe-core";
 import { fetchClaimSummaries } from "../actions";
 import { MODULE_NAME } from "../constants";
+
+const VisibilityIcon = GetIconComponent("Visibility")
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
   ...(theme?.paper?.paper ?? {}),

--- a/src/components/ClaimSearcher.jsx
+++ b/src/components/ClaimSearcher.jsx
@@ -12,7 +12,6 @@ import {
   withModulesManager,
   GetIconComponent,
 } from "@openimis/fe-core";
-import { RIGHT_CLAIMREVIEW } from "../constants";
 import _ from "lodash";
 import { injectIntl } from "react-intl";
 import { connect } from "react-redux";

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import { decodeId, GetIconComponent } from "@openimis/fe-core";
-const Keyboard = GetIconComponent("Keyboard")
-const ScreenShare = GetIconComponent("ScreenShare")
-const Assignment= GetIconComponent("Assignment")
-import { FormattedMessage } from "@openimis/fe-core";
+import { decodeId, GetIconComponent, FormattedMessage } from "@openimis/fe-core";
 import HealthFacilitiesPage from "./pages/HealthFacilitiesPage";
 import EditPage from "./pages/EditPage";
 import ReviewsPage from "./pages/ReviewsPage";
@@ -33,6 +29,10 @@ import ClaimInsureeSummary from "./components/ClaimInsureeSummary";
 import YesNoPicker from "./pickers/YesNoPicker";
 import PatientConditionPicker from "./pickers/PatientConditionPicker";
 import { RIGHT_ADD, RIGHT_SUBMIT, RIGHT_CLAIMREVIEW, RIGHT_PROCESS, RIGHT_FEEDBACK, RIGHT_SEARCH, RIGHT_HF_SEARCH } from "./constants";
+
+const Keyboard = GetIconComponent("Keyboard")
+const ScreenShare = GetIconComponent("ScreenShare")
+const Assignment = GetIconComponent("Assignment")
 
 const ROUTE_HEALTH_FACILITIES = "claim/healthFacilities";
 const ROUTE_CLAIM_EDIT = "claim/healthFacilities/claim";


### PR DESCRIPTION
## Problem

These files contain syntax patterns that CRA (Webpack) silently tolerated but are rejected by Vite/esbuild, which strictly enforces ESM rules. This prevents the module from loading when running under Vite.

## Changes

### `src/index.jsx`

- Merged duplicate `@openimis/fe-core` imports into a single import statement.
- Moved `GetIconComponent` constant declarations below all import statements, as ESM requires imports to appear before any other statements.

### `src/components/ClaimSearcher.jsx`

- Removed the duplicate import of `RIGHT_CLAIMREVIEW` from `../constants` (it was declared twice, causing an `Identifier already declared` error).

### `src/components/ClaimFilter.jsx`

- Removed the duplicate import of `RIGHT_CLAIMREVIEW` from `../constants`.

### `src/components/ClaimForm.jsx`

- Removed the duplicate import of `ClaimHistoryPanel` from `./ClaimHistoryPanel`.
- Fixed an unclosed `<Fragment>` in the render method. `</StyledDiv>` was incorrectly used where `</Fragment>` and `)}` were required, causing a JSX parsing error.

### `src/components/ClaimInsureeSummary.jsx`

- Moved an import statement that appeared after a constant declaration to the top of the file with the other imports.

## Root Cause

These issues appear to be artifacts from the class-to-functional component migration and subsequent refactoring. CRA/Webpack bundles modules without strict ESM parsing, allowing these patterns to pass unnoticed. Vite uses esbuild, which enforces strict ESM parsing and fails immediately when encountering such syntax violations.

## Testing

- Verified that all affected files parse successfully under Vite v7.
- Confirmed there are no bundling or module-loading errors after the fixes.