### PR TITLE
fix resize seacher panel when select

### DIFF
--- a/src/pages/ReviewsPage.jsx
+++ b/src/pages/ReviewsPage.jsx
@@ -474,7 +474,7 @@ class ReviewsPage extends Component {
   provideFeedback = (c) => historyPush(this.props.modulesManager, this.props.history, "claim.route.feedback", [c.uuid]);
 
   feedbackColFormatter = (c) => (
-    <Grid container justifyContent="flex-end" alignItems="center">
+    <Grid container alignItems="center" wrap="nowrap" style={{ gap: 4 }}>
       <Grid>
         <PublishedComponent
           pubRef="claim.FeedbackStatusPicker"
@@ -550,7 +550,7 @@ class ReviewsPage extends Component {
     }
   };
   reviewColFormatter = (c) => (
-    <Grid container justifyContent="flex-end" alignItems="center">
+    <Grid container alignItems="center" wrap="nowrap" style={{ gap: 4 }}>
       <Grid>
         <PublishedComponent
           pubRef="claim.ReviewStatusPicker"


### PR DESCRIPTION
# Description

In the review screen, when a claim is selected, the size of the panel containing the service decreases. This makes it difficult to open a service by double-clicking on it

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/5f74078e-6877-4da2-8435-4b527f49c239



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
