### PR TITLE
Spacing Issue Between Insured Number and Insured Name Fields

### DIFF
--- a/src/components/ClaimForm.jsx
+++ b/src/components/ClaimForm.jsx
@@ -136,9 +136,9 @@ class ClaimForm extends Component {
     claim.healthFacility =
       this?.state?.claim?.healthFacility ??
       this.props.claimHealthFacility ??
-      JSON.parse(getLocalStorage(STORAGE_KEY_CLAIM_HEALTH_FACILITY));
+      getLocalStorage(STORAGE_KEY_CLAIM_HEALTH_FACILITY);
     claim.admin =
-      this?.state?.claim?.admin ?? this.props.claimAdmin ?? JSON.parse(getLocalStorage(STORAGE_KEY_ADMIN));
+      this?.state?.claim?.admin ?? this.props.claimAdmin ?? getLocalStorage(STORAGE_KEY_ADMIN);
     claim.status = this.props.modulesManager.getConf("fe-claim", "newClaim.status", 2);
     claim.dateClaimed = toISODate(moment().toDate());
     claim.dateFrom = toISODate(moment().toDate());

--- a/src/components/ClaimMasterPanel.jsx
+++ b/src/components/ClaimMasterPanel.jsx
@@ -180,7 +180,7 @@ class ClaimMasterPanel extends FormPanel {
           module="claim"
           id="Claim.insuree"
           field={
-            <StyledItemGrid size={GRID_RESPONSIVE_STANDARD} className="item">
+            <StyledItemGrid size={GRID_RESPONSIVE_LARGE} className="item">
               <PublishedComponent
                 pubRef={this.insureePicker}
                 value={edited.insuree}
@@ -197,7 +197,7 @@ class ClaimMasterPanel extends FormPanel {
           module="claim"
           id="Claim.visitDateFrom"
           field={
-            <StyledItemGrid size={GRID_RESPONSIVE_STANDARD} className="item">
+            <StyledItemGrid size={GRID_RESPONSIVE_SMALL} className="item">
               <PublishedComponent
                 pubRef="core.DatePicker"
                 value={edited.dateFrom}
@@ -221,7 +221,7 @@ class ClaimMasterPanel extends FormPanel {
           module="claim"
           id="Claim.visitDateTo"
           field={
-            <StyledItemGrid size={GRID_RESPONSIVE_STANDARD} className="item">
+            <StyledItemGrid size={GRID_RESPONSIVE_SMALL} className="item">
               <PublishedComponent
                 pubRef="core.DatePicker"
                 value={edited.dateTo}
@@ -246,7 +246,7 @@ class ClaimMasterPanel extends FormPanel {
           module="claim"
           id="Claim.claimedDate"
           field={
-            <StyledItemGrid size={GRID_RESPONSIVE_STANDARD} className="item">
+            <StyledItemGrid size={GRID_RESPONSIVE_SMALL} className="item">
               <PublishedComponent
                 pubRef="core.DatePicker"
                 value={edited.dateClaimed ?? new Date()}
@@ -270,7 +270,7 @@ class ClaimMasterPanel extends FormPanel {
           module="claim"
           id="Claim.visitType"
           field={
-            <StyledItemGrid size={GRID_RESPONSIVE_STANDARD} className="item">
+            <StyledItemGrid size={GRID_RESPONSIVE_SMALL} className="item">
               <PublishedComponent
                 pubRef="medical.VisitTypePicker"
                 name="visitType"
@@ -289,7 +289,7 @@ class ClaimMasterPanel extends FormPanel {
           module="claim"
           id="Claim.careType"
           field={
-            <StyledItemGrid size={GRID_RESPONSIVE_STANDARD} className="item">
+            <StyledItemGrid size={GRID_RESPONSIVE_SMALL} className="item">
               <PublishedComponent
                 pubRef="claim.CareTypePicker"
                 name="careType"


### PR DESCRIPTION
# Description

In the claim form, the Insured Number field is too close to the Insured Name field
I added spacing and adjusted the size of the dateFrom, dateTo, and dateClaimed fields, as they were approximately twice as wide as necessary for their content. I also applied the same adjustment to the visitType and careType fields

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires [https://github.com/openimis/openimis-fe-insuree_js/pull/193], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1200" height="443" alt="Screenshot 2026-07-07 at 4 41 31 PM" src="https://github.com/user-attachments/assets/8dc82266-4db4-4c39-9ea7-1b601fc0a29f" />
<img width="1430" height="744" alt="Screenshot 2026-07-08 at 4 14 08 PM" src="https://github.com/user-attachments/assets/eb6e34d1-09ba-455c-b72e-4c2b517f1813" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
