### PR TITLE
hide panels without items during review

### DIFF
--- a/src/components/ClaimForm.jsx
+++ b/src/components/ClaimForm.jsx
@@ -480,6 +480,10 @@ class ClaimForm extends Component {
       return;
     };
 
+    const claimPanels = [];
+    if (!forReview || claim?.services?.length > 0) claimPanels.push(ClaimServicesPanel);
+    if (!forReview || claim?.items?.length > 0) claimPanels.push(ClaimItemsPanel);  
+
     let readOnly =
       lockNew ||
       isSaved ||
@@ -611,7 +615,7 @@ class ClaimForm extends Component {
               title="edit.title"
               titleParams={{ code: this.state.claim.code }}
               HeadPanel={ClaimMasterPanel}
-              Panels={!!forFeedback ? [ClaimFeedbackPanel] : [ClaimServicesPanel, ClaimItemsPanel]}
+              Panels={!!forFeedback ? [ClaimFeedbackPanel] : claimPanels }
               openDirty={save || forReview}
               additionalTooltips={tooltips}
               {...editingProps}


### PR DESCRIPTION
# Description

During the review process, if a claim does not contain any items, only the header of the items table is displayed.
The Services or Items panel is displayed only under the following conditions:
- The user is not in the review workflow (e.g., claim creation or editing).
- During the review workflow, the panel is displayed only if the corresponding list is not empty

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/dc1d6ccf-2d84-4c6a-8ace-5297a2a0f07b



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
