### PR TITLE
fix mismatch amount in detail & searcher

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -635,8 +635,8 @@ export function formatReviewDetail(type, detail) {
     ${detail.qtyApproved !== null ? `qtyApproved: "${_.round(detail.qtyApproved, 2).toFixed(2)}"` : ""}
     ${detail.priceApproved !== null ? `priceApproved: "${_.round(detail.priceApproved, 2).toFixed(2)}"` : ""}
     ${detail.justification !== null ? `justification: "${formatGQLString(detail.justification)}"` : ""}
-    ${subServices !== null ?  `serviceServiceSet: [ ${subServices.map((d) => formatDetailSubService(type, d)).join("\n")}]` : ""} 
-    ${subItems !== null ?  `serviceItemSet: [ ${subItems.map((d) => formatDetailSubService(type, d)).join("\n")}]` : ""}
+    ${type == 'service' && subServices !== null ?  `serviceServiceSet: [ ${subServices.map((d) => formatDetailSubService(type, d)).join("\n")}]` : ""} 
+    ${type == 'service' && subItems !== null ?  `serviceItemSet: [ ${subItems.map((d) => formatDetailSubService(type, d)).join("\n")}]` : ""}
     status: ${detail.status}
     ${detail.rejectionReason !== null ? `rejectionReason: ${detail.rejectionReason}` : ""}
   }`;

--- a/src/components/ClaimChildPanel.jsx
+++ b/src/components/ClaimChildPanel.jsx
@@ -611,7 +611,7 @@ class ClaimChildPanel extends Component {
         itemFormatters.push((i, idx) => (
           <AmountInput
             readOnly={!forReview && readOnly}
-            value={i.priceApproved}
+            value={i.priceApproved || i.priceAdjusted}
             onChange={(v) => this._onChange(idx, "priceApproved", v)}
           />
         ));

--- a/src/helpers/amounts.js
+++ b/src/helpers/amounts.js
@@ -15,8 +15,8 @@ export function claimedAmount(r) {
             if (r?.service.manualPrice) {
               totalPrice += parseFloat(r.service.price);
             } else {
-              var subServices = r.service?.serviceServiceSet || r.service?.serviceserviceSet || r.services;
-              var subItems = r.service.serviceItemSet || r.service.servicesLinked || r.items;
+              var subServices = r.service?.serviceServiceSet || r.service?.serviceserviceSet || r.services || r.subServices;
+              var subItems = r.service.serviceItemSet || r.service.servicesLinked || r.items || r.subItems;
               if (!!subServices) {
                 subServices.forEach(subService => {
                   let qtyAsked = 0;
@@ -108,8 +108,9 @@ export function approvedAmount(r) {
     if (r?.service) {
       let currentPackageType = r.service.packagetype;
       if (currentPackageType == SERVICE_TYPE_PP_S) {
+        let qty = r.qtyApproved !== null && r.qtyApproved !== "" ? r.qtyApproved : r.qtyProvided;
         let price = r.priceApproved !== null && r.priceApproved !== "" ? r.priceApproved : r.priceAsked;
-        totalPrice += parseFloat(price);
+        return qty * parseFloat(price);
       } else {
         if (r?.services) {
           r.services.forEach(subItem => {

--- a/src/helpers/amounts.js
+++ b/src/helpers/amounts.js
@@ -4,16 +4,16 @@ export function claimedAmount(r) {
   let totalPrice = 0;
   if (Object?.keys(r)?.length != 0) {
     if ('item' in r) {
-      return !!r.qtyProvided && !!r.priceAsked ? r.qtyProvided * parseFloat(r.priceAsked) : 0;
+      return !!r.qtyProvided && !!r.priceAsked ? r.qtyProvided * Number.parseFloat(r.priceAsked) : 0;
     } else {
       if (r?.service) {
         if (Object?.keys(r.service)?.length != 0) {
           let currentPackageType = r.service.packagetype;
           if (currentPackageType == SERVICE_TYPE_PP_S) {
-            totalPrice += (r?.qtyProvided * parseFloat(r.priceAsked));
+            totalPrice += (r?.qtyProvided * Number.parseFloat(r.priceAsked));
           } else {
             if (r?.service.manualPrice) {
-              totalPrice += parseFloat(r.service.price);
+              totalPrice += Number.parseFloat(r.service.price);
             } else {
               var subServices = r.service?.serviceServiceSet || r.service?.serviceserviceSet || r.services || r.subServices;
               var subItems = r.service.serviceItemSet || r.service.servicesLinked || r.items || r.subItems;
@@ -103,14 +103,14 @@ export function approvedAmount(r) {
   if ('item' in r) {
     let qty = r.qtyApproved !== null && r.qtyApproved !== "" ? r.qtyApproved : r.qtyProvided;
     let price = r.priceApproved !== null && r.priceApproved !== "" ? r.priceApproved : r.priceAsked;
-    return qty * parseFloat(price);
+    return qty * Number.parseFloat(price);
   } else {
     if (r?.service) {
       let currentPackageType = r.service.packagetype;
       if (currentPackageType == SERVICE_TYPE_PP_S) {
         let qty = r.qtyApproved !== null && r.qtyApproved !== "" ? r.qtyApproved : r.qtyProvided;
         let price = r.priceApproved !== null && r.priceApproved !== "" ? r.priceApproved : r.priceAsked;
-        return qty * parseFloat(price);
+        return qty * Number.parseFloat(price);
       } else {
         if (r?.services) {
           r.services.forEach(subItem => {


### PR DESCRIPTION
# Description

The approved amount displayed in the claim list differed from the approved amount shown in the service details.
The issue was caused by the approved amount calculation in the amount.js file, which was using incorrect quantities. I updated the calculation to use the appropriate quantities, ensuring consistency between the list and the service details.

When I reviewed the service and item quantities, a Bad Request error occurred while saving.
The issue was caused by the serviceServiceSet and serviceItemSet fields, which were still included in the claim items when the mutation was sent from the actions.js file. These fields are not expected by the backend during the update operation.
I removed these fields from the mutation payload, which resolved the issue

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1345" height="130" alt="Screenshot 2026-07-19 at 9 51 49 AM" src="https://github.com/user-attachments/assets/639bbe4e-1db9-439a-9f42-6e1cff0786fb" />
<img width="1361" height="525" alt="Screenshot 2026-07-19 at 9 52 12 AM" src="https://github.com/user-attachments/assets/a56eb8d0-78a2-4c3c-824d-f74806af5907" />
<img width="1338" height="457" alt="Screenshot 2026-07-19 at 9 18 57 AM" src="https://github.com/user-attachments/assets/1f083418-d902-44ca-884d-696b575484f2" />
<img width="1426" height="737" alt="Screenshot 2026-07-19 at 9 20 43 AM" src="https://github.com/user-attachments/assets/a397d5f4-ac0c-469e-a274-be75c9ff7b9c" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
