### PR TITLE
hide actions button in searcher

### DIFF
--- a/src/components/ClaimSearcher.jsx
+++ b/src/components/ClaimSearcher.jsx
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from "react";
-import { Badge, Button, TextField, Tooltip, Typography } from "@mui/material";
+import { Badge, Button, TextField, Typography } from "@mui/material";
 import { RIGHT_CLAIMREVIEW } from "../constants";
 import {
   formatAmount,

--- a/src/components/ClaimSearcher.jsx
+++ b/src/components/ClaimSearcher.jsx
@@ -11,6 +11,7 @@ import {
   Searcher,
   withModulesManager,
   GetIconComponent,
+  ActionMenu
 } from "@openimis/fe-core";
 import _ from "lodash";
 import { injectIntl } from "react-intl";
@@ -308,11 +309,16 @@ class ClaimSearcher extends Component {
       });
     }
     result.push((c) => (
-      <Tooltip title={formatMessage(this.props.intl, "claim", "openNewTabButton.tooltip")}>
-        <Button startIcon={<TabIcon />} onClick={(e) => this.props.onDoubleClick(c, true)}>
-          {formatMessage(this.props.intl, "claim", "openNewTab.buttonText")}
-        </Button>
-      </Tooltip>
+      <ActionMenu 
+        actions={[
+          {
+            icon: <TabIcon />,
+            label: formatMessage(this.props.intl, "claim", "openNewTab.buttonText"),
+            tooltip: formatMessage(this.props.intl, "claim", "openNewTabButton.tooltip"),
+            onClick: () => this.props.onDoubleClick(c, true)
+          }
+        ]}
+      />
     ));
     return result;
   };


### PR DESCRIPTION
# Description

Hide the action buttons in the list to free up space and improve the table layout

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires [https://github.com/openimis/openimis-fe-core_js/pull/342], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1429" height="244" alt="Screenshot 2026-07-31 at 6 16 22 PM" src="https://github.com/user-attachments/assets/24d580ba-c338-4522-b9fd-22c954ab9e4d" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
